### PR TITLE
Fixed bug in pool_rm

### DIFF
--- a/src/pooler_sup.erl
+++ b/src/pooler_sup.erl
@@ -41,7 +41,7 @@ rm_pool(Name) ->
         {error, not_found} ->
             ok;
         ok ->
-            supervisor:terminate_child(?MODULE, SupName);
+            supervisor:delete_child(?MODULE, SupName);
         Error ->
             Error
     end.


### PR DESCRIPTION
When removing a pool it was not possible to create a new one with the same name as in:

``` erlang
Spec = [{name, pool_a}...],
pooler:new_pool(Spec), % => {ok, <some.pid.yap>}
pooler:rm_pool(pool_a}...]),
pooler:new_pool(Spec), % => {error, already_present}
```

the original code for rm_pool read:

``` erlang
rm_pool(Name) ->
    SupName = pool_sup_name(Name),
    case supervisor:terminate_child(?MODULE, SupName) of
        {error, not_found} ->
            ok;
        ok ->
            supervisor:terminate_child(?MODULE, SupName);
        Error ->
            Error
    end.
```

Line 7 calls `supervisor:terminate_child` a second time, my guess is that actually `supervisor:delete_child` was meant here to remove the child from the supervisor so it can be added again later.
