### PR TITLE
Replace dict() to dict:dict() for disable warning for Erlang 17.0

### DIFF
--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -537,7 +537,7 @@ clean_group_table(MemberPid, #pool{group = _GroupName}) ->
 % If `Pid' is the last element in `CPid's pid list, then the `CPid'
 % entry is removed entirely.
 %
--spec cpmap_remove(pid(), pid() | free, dict()) -> dict().
+-spec cpmap_remove(pid(), pid() | free, dict:dict()) -> dict:dict().
 cpmap_remove(_Pid, free, CPMap) ->
     CPMap;
 cpmap_remove(Pid, CPid, CPMap) ->
@@ -594,18 +594,18 @@ remove_pid(Pid, Pool) ->
     end.
 
 -spec store_all_members(pid(),
-                        {reference(), free | pid(), {_, _, _}}, dict()) -> dict().
+                        {reference(), free | pid(), {_, _, _}}, dict:dict()) -> dict:dict().
 store_all_members(Pid, Val = {_MRef, _CPid, _Time}, AllMembers) ->
     dict:store(Pid, Val, AllMembers).
 
--spec set_cpid_for_member(pid(), pid(), dict()) -> dict().
+-spec set_cpid_for_member(pid(), pid(), dict:dict()) -> dict:dict().
 set_cpid_for_member(MemberPid, CPid, AllMembers) ->
     dict:update(MemberPid,
                 fun({MRef, free, Time = {_, _, _}}) ->
                         {MRef, CPid, Time}
                 end, AllMembers).
 
--spec add_member_to_consumer(pid(), pid(), dict()) -> dict().
+-spec add_member_to_consumer(pid(), pid(), dict:dict()) -> dict:dict().
 add_member_to_consumer(MemberPid, CPid, CPMap) ->
     %% we can't use dict:update here because we need to create the
     %% monitor if we aren't already tracking this consumer.
@@ -660,7 +660,7 @@ schedule_cull(PoolName, Delay) ->
     %% automatic cancelling
     erlang:send_after(DelayMillis, PoolName, cull_pool).
 
--spec member_info([pid()], dict()) -> [{pid(), member_info()}].
+-spec member_info([pid()], dict:dict()) -> [{pid(), member_info()}].
 member_info(Pids, AllMembers) ->
     [ {P, dict:fetch(P, AllMembers)} || P <- Pids ].
 

--- a/src/pooler.hrl
+++ b/src/pooler.hrl
@@ -46,13 +46,13 @@
           %% Status is either 'free' or the consumer pid, and Time is
           %% an Erlang timestamp that records when the member became
           %% free.
-          all_members = dict:new()     :: dict(),
+          all_members = dict:new()     :: dict:dict(),
 
           %% Maps consumer pid to a tuple of the form:
           %% {MonitorRef, MemberList} where MonitorRef is a monitor
           %% reference for the consumer and MemberList is a list of
           %% members being consumed.
-          consumer_to_pid = dict:new() :: dict(),
+          consumer_to_pid = dict:new() :: dict:dict(),
 
           %% A list of `{References, Timestamp}' tuples representing
           %% new member start requests that are in-flight. The


### PR DESCRIPTION
Replace dict() to dict:dict() for disable warning R17.0: 
Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
