### PR TITLE
Set nowarn_deprecated_type erl_opt for R17 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: erlang
 otp_release:
-  - R15B02
-  - R15B01
-  - R15B
-  - R14B04
-  - R14B03
-  - R14B02
+  - 17.0-rc1
+  - R16B03-1
+  - R15B03

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,8 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
+%% Type spec dict() is deprecated in R17 to be removed in R18 in
+%% preference for dict:dict(). But the fix is not compatible with <=
+%% R16.
+{erl_opts, [nowarn_deprecated_type]}.
 {cover_enabled, true}.


### PR DESCRIPTION
R17 deprecates built-in type spec for dict() in favor of
dict:dict(). However, the latter is not available in R16 and below and
is a compile time error. Ignoring the warning isn't great, but allows
the code to compile clean on R16 and R17.

Also updating the list of supported/tested Erlang versions in the travis
yaml.
