### PR TITLE
Add the possibility of using Exometer for the metrics instead of Folsom

### DIFF
--- a/src/pooler.hrl
+++ b/src/pooler.hrl
@@ -74,7 +74,11 @@
           %% 'pooler_no_metrics', then metric sending calls do
           %% nothing. A typical value to actually capture metrics is
           %% folsom_metrics.
-          metrics_mod = pooler_no_metrics :: atom()
+          metrics_mod = pooler_no_metrics :: atom(),
+
+          %% The API used to call the metrics system. It supports both Folsom
+          %% and Exometer format.
+          metrics_api = folsom :: 'folsom' | 'exometer'
          }).
 
 -define(gv(X, Y), proplists:get_value(X, Y)).

--- a/src/pooler_config.erl
+++ b/src/pooler_config.erl
@@ -20,7 +20,8 @@ list_to_pool(P) ->
        cull_interval     = ?gv(cull_interval, P, ?DEFAULT_CULL_INTERVAL),
        max_age           = ?gv(max_age, P, ?DEFAULT_MAX_AGE),
        member_start_timeout = ?gv(member_start_timeout, P, ?DEFAULT_MEMBER_START_TIMEOUT),
-       metrics_mod       = ?gv(metrics_mod, P, pooler_no_metrics)}.
+       metrics_mod       = ?gv(metrics_mod, P, pooler_no_metrics),
+       metrics_api       = ?gv(metrics_api, P, folsom)}.
 
 %% Return `Value' for `Key' in proplist `P' or crashes with an
 %% informative message if no value is found.


### PR DESCRIPTION
I don't know whether you find this useful or not ... I added the possibility of calling the Exometer API for the metrics storage instead of the Folsom one.

There are two configuration parameters `{metrics_module, callback_module}`  and `{metrics_api,  exometer | folsom}`. In this way it is possible to configure which API will be called and also to provide a custom callback module if wanted.
