### PR TITLE
Lazy loading pools

### DIFF
--- a/src/pooler.hrl
+++ b/src/pooler.hrl
@@ -20,6 +20,7 @@
           group            :: atom(),
           max_count = 100  :: non_neg_integer(),
           init_count = 10  :: non_neg_integer(),
+          lazy = false     :: boolean(),
           start_mfa        :: {atom(), atom(), [term()]},
           free_pids = []   :: [pid()],
           in_use_count = 0 :: non_neg_integer(),

--- a/src/pooler_config.erl
+++ b/src/pooler_config.erl
@@ -15,6 +15,7 @@ list_to_pool(P) ->
        group             = ?gv(group, P),
        max_count         = req(max_count, P),
        init_count        = req(init_count, P),
+       lazy              = ?gv(lazy, P, false),
        start_mfa         = req(start_mfa, P),
        add_member_retry  = ?gv(add_member_retry, P, ?DEFAULT_ADD_RETRY),
        cull_interval     = ?gv(cull_interval, P, ?DEFAULT_CULL_INTERVAL),


### PR DESCRIPTION
It wasn't possible before to create an empty pool and have it lazily load members once it starts being used. This is useful when you don't have the information you need to start members when creating the pool
