### PR TITLE
Of/kill stale started members

### DIFF
--- a/src/pooler_starter.erl
+++ b/src/pooler_starter.erl
@@ -12,9 +12,10 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 
--export([start_link/3,
+-export([start_link/2,
          start_member/1,
          start_member/2,
+         stop_member_async/1,
          stop/1]).
 
 %% ------------------------------------------------------------------
@@ -37,66 +38,91 @@
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
-start_link(Pool, Ref, Parent) ->
-    gen_server:start_link(?MODULE, {Pool, Ref, Parent}, []).
+start_link(Pool, Parent) ->
+    gen_server:start_link(?MODULE, {Pool, Parent}, []).
 
 stop(Starter) ->
-    gen_server:call(Starter, stop).
+    gen_server:cast(Starter, stop).
 
 %% @doc Start a member for the specified `Pool'.
 %%
 %% Member creation with this call is async. This function returns
-%% immediately with a reference. When the member has been created it
-%% is sent to the specified pool via {@link pooler:accept_member/2}.
+%% immediately with create process' pid. When the member has been
+%% created it is sent to the specified pool via
+%% {@link pooler:accept_member/2}.
 %%
 %% Each call starts a single use `pooler_starter' instance via
 %% `pooler_starter_sup'. The instance terminates normally after
 %% creating a single member.
--spec start_member(#pool{}) -> reference().
+-spec start_member(#pool{}) -> pid().
 start_member(Pool) ->
-    Ref = make_ref(),
-    {ok, _Pid} = pooler_starter_sup:new_starter(Pool, Ref, pool),
-    Ref.
+    {ok, Pid} = pooler_starter_sup:new_starter(Pool, pool),
+    Pid.
 
 %% @doc Same as {@link start_member/1} except that instead of calling
 %% {@link pooler:accept_member/2} a raw message is sent to `Parent' of
 %% the form `{accept_member, {Ref, Member}'. Where `Member' will
 %% either be the member pid or an error term and `Ref' will be the
-%% reference returned from this function.
+%% Pid of the starter.
 %%
 %% This is used by the init function in the `pooler' to start the
 %% initial set of pool members in parallel.
 start_member(Pool, Parent) ->
-    Ref = make_ref(),
-    {ok, _Pid} = pooler_starter_sup:new_starter(Pool, Ref, Parent),
-    Ref.
+    {ok, Pid} = pooler_starter_sup:new_starter(Pool, Parent),
+    Pid.
+
+%% @doc Stop a member in the pool
+
+%% Member creation can take too long. In this case, the starter
+%% needs to be informed that even if creation succeeds, the
+%% started child should be not be sent back and should be
+%% cleaned up
+-spec stop_member_async(pid()) -> ok.
+stop_member_async(Pid) ->
+    gen_server:cast(Pid, stop_member).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 -record(starter, {pool,
-                  ref,
-                  parent}).
+                  parent,
+                  msg}).
 
--spec init({#pool{}, reference(), pid() | atom()}) -> {'ok', #starter{}, 0}.
-init({Pool, Ref, Parent}) ->
+-spec init({#pool{}, pid() | atom()}) -> {'ok', #starter{}, 0}.
+init({Pool, Parent}) ->
     %% trigger immediate timeout message, which we'll use to trigger
     %% the member start.
-    {ok, #starter{pool = Pool, ref = Ref, parent = Parent}, 0}.
+    {ok, #starter{pool = Pool, parent = Parent}, 0}.
 
-handle_call(stop, _From, State) ->
-    {stop, normal, stop_ok, State};
 handle_call(_Request, _From, State) ->
     {noreply, State}.
+
+handle_cast(stop_member, #starter{msg = {_Me, Pid}, pool = #pool{member_sup = MemberSup}} = State) ->
+    %% The process we were starting is no longer valid for the pool.
+    %% Cleanup the process and stop normally.
+    supervisor:terminate_child(MemberSup, Pid),
+    {stop, normal, State};
+
+handle_cast(accept_member, #starter{msg = Msg, parent = Parent, pool = #pool{name = PoolName}} = State) ->
+    %% Process creation has succeeded. Send the member to the pooler
+    %% gen_server to be accepted. Pooler gen_server will notify
+    %% us if the member was accepted or needs to cleaned up.
+    send_accept_member(Parent, PoolName, Msg),
+    {noreply, State};
+
+handle_cast(stop, State) ->
+    {stop, normal, stop_ok, State};
+
 
 handle_cast(_Request, State) ->
     {noreply, State}.
 
 -spec handle_info(_, _) -> {'noreply', _}.
 handle_info(timeout,
-            #starter{pool = Pool, ref = Ref, parent = Parent} = State) ->
-    ok = do_start_member(Pool, Ref, Parent),
-    {stop, normal, State};
+            #starter{pool = Pool} = State) ->
+    Msg = do_start_member(Pool),
+    accept_member_async(self()),
+    {noreply, State#starter{msg = Msg}};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -108,20 +134,21 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-do_start_member(#pool{name = PoolName, member_sup = PoolSup}, Ref, Parent) ->
-    Msg = case supervisor:start_child(PoolSup, []) of
-              {ok, Pid} ->
-                  {Ref, Pid};
-              Error ->
-                  error_logger:error_msg("pool '~s' failed to start member: ~p",
-                                         [PoolName, Error]),
-                  {Ref, Error}
-          end,
-    send_accept_member(Parent, PoolName, Msg),
-    ok.
+do_start_member(#pool{member_sup = PoolSup, name = PoolName}) ->
+    case supervisor:start_child(PoolSup, []) of
+        {ok, Pid} ->
+            {self(), Pid};
+        Error ->
+            error_logger:error_msg("pool '~s' failed to start member: ~p",
+                                   [PoolName, Error]),
+            {self(), Error}
+    end.
 
 send_accept_member(pool, PoolName, Msg) ->
     pooler:accept_member(PoolName, Msg);
 send_accept_member(Pid, _PoolName, Msg) ->
     Pid ! {accept_member, Msg},
     ok.
+
+accept_member_async(Pid) ->
+    gen_server:cast(Pid, accept_member).

--- a/src/pooler_starter_sup.erl
+++ b/src/pooler_starter_sup.erl
@@ -6,14 +6,14 @@
 
 -behaviour(supervisor).
 
--export([new_starter/3,
+-export([new_starter/2,
          start_link/0,
          init/1]).
 
 -include("pooler.hrl").
 
-new_starter(Pool, Ref, Parent) ->
-    supervisor:start_child(?MODULE, [Pool, Ref, Parent]).
+new_starter(Pool, Parent) ->
+    supervisor:start_child(?MODULE, [Pool, Parent]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/test/pooled_gs.erl
+++ b/test/pooled_gs.erl
@@ -36,6 +36,10 @@
 
 start_link(Args ={_Type}) ->
     % not registered
+    gen_server:start_link(?MODULE, Args, []);
+
+start_link(Args ={_Type, _InitFun}) ->
+    % not registered
     gen_server:start_link(?MODULE, Args, []).
 
 %% @doc return the type argument passed to this worker at start time
@@ -73,7 +77,12 @@ stop(S) ->
          }).
 
 init({Type}) ->
+    {ok, #state{type = Type, id = make_ref()}};
+init({Type, StartFun}) ->
+    StartFun(),
     {ok, #state{type = Type, id = make_ref()}}.
+
+
 
 handle_call(get_id, _From, State) ->
     {reply, {State#state.type, State#state.id}, State};


### PR DESCRIPTION
Clean up starting members that took too long to start. Corrects some bookkeeping issues with regard to starting members.
