### PR TITLE
Queueing requestors with an external api

### DIFF
--- a/src/pooler_config.erl
+++ b/src/pooler_config.erl
@@ -21,7 +21,8 @@ list_to_pool(P) ->
        max_age           = ?gv(max_age, P, ?DEFAULT_MAX_AGE),
        member_start_timeout = ?gv(member_start_timeout, P, ?DEFAULT_MEMBER_START_TIMEOUT),
        metrics_mod       = ?gv(metrics_mod, P, pooler_no_metrics),
-       metrics_api       = ?gv(metrics_api, P, folsom)}.
+       metrics_api       = ?gv(metrics_api, P, folsom),
+       queue_max         = ?gv(queue_max, P, ?DEFAULT_POOLER_QUEUE_MAX)}.
 
 %% Return `Value' for `Key' in proplist `P' or crashes with an
 %% informative message if no value is found.


### PR DESCRIPTION
Take member queuing:

There is a new options to configure a pool:
queue_max: Maximum depth of the requestor queue before returning error_no_members

Semantics are as follows
pooler:take_member/2 makes a blocking request to pooler. The second argument is a timeout after which, the pool will reply with error_no_members. If queue_max has been reached, error_no_members will be returned immediately. 
take_member/1 is now an alias to take_member_queued/2 with the timeout set to zero
