### PR TITLE
Add optional `auto_grow_threshold` for anticipatory growth

### DIFF
--- a/src/pooler.hrl
+++ b/src/pooler.hrl
@@ -2,6 +2,7 @@
 -define(DEFAULT_CULL_INTERVAL, {1, min}).
 -define(DEFAULT_MAX_AGE, {30, sec}).
 -define(DEFAULT_MEMBER_START_TIMEOUT, {1, min}).
+-define(DEFAULT_AUTO_GROW_THRESHOLD, undefined).
 -define(POOLER_GROUP_TABLE, pooler_group_table).
 -define(DEFAULT_POOLER_QUEUE_MAX, 50).
 
@@ -72,6 +73,12 @@
 
           %% The maximum amount of time to allow for member start.
           member_start_timeout = ?DEFAULT_MEMBER_START_TIMEOUT :: time_spec(),
+
+          %% The optional threshold at which more members will be started if
+          %% free_count drops to this value.  Normally undefined, but may be
+          %% set to a non-negative integer in order to enable "anticipatory"
+          %% behavior (start members before they're actually needed).
+          auto_grow_threshold = ?DEFAULT_AUTO_GROW_THRESHOLD :: undefined | non_neg_integer(),
 
           %% The module to use for collecting metrics. If set to
           %% 'pooler_no_metrics', then metric sending calls do

--- a/src/pooler_config.erl
+++ b/src/pooler_config.erl
@@ -20,6 +20,7 @@ list_to_pool(P) ->
        cull_interval     = ?gv(cull_interval, P, ?DEFAULT_CULL_INTERVAL),
        max_age           = ?gv(max_age, P, ?DEFAULT_MAX_AGE),
        member_start_timeout = ?gv(member_start_timeout, P, ?DEFAULT_MEMBER_START_TIMEOUT),
+       auto_grow_threshold = ?gv(auto_grow_threshold, P, ?DEFAULT_AUTO_GROW_THRESHOLD),
        metrics_mod       = ?gv(metrics_mod, P, pooler_no_metrics),
        metrics_api       = ?gv(metrics_api, P, folsom),
        queue_max         = ?gv(queue_max, P, ?DEFAULT_POOLER_QUEUE_MAX)}.


### PR DESCRIPTION
We have a use case where our pool needs to start relatively small (`init_conn=1000`) but grow quite large over time (`max_conn=65535`).  And...we want to avoid at all costs getting `error_no_members` when trying to take a member from the pool.  The caller should not ever have to wait for a new member to be started.

To that end, I've added a new `auto_grow_threshold` feature.  It's fully backward compatible, in that it's `undefined` by default.  There is no change whatsoever for existing `pooler` users.

For those who choose to set `auto_grow_threshold` to a non-negative integer, however, they will benefit from members being started prior to all free members having been exhausted.

The idea is that when `free_count` drops to `auto_grow_threshold`, a new batch of members will be started in the background.  By the time `free_count` would have dropped to zero, there's already a new batch waiting & ready.  In fact, `free_count` never drops to zero in the first place (as long as member start can keep up with the take demand).

This has already proven to work extremely well for us -- we avoid the "cliff" behavior and see the pool growing smartly in advance of the demand.