### PR TITLE
Switch from erlang:now/0 to os:timestamp/0

### DIFF
--- a/bench/src/consumer.erl
+++ b/bench/src/consumer.erl
@@ -47,7 +47,7 @@ run(S, Config) ->
          }).
 
 init([]) ->
-    Now = erlang:now(),
+    Now = os:timestamp(),
     random:seed(Now),
     {ok, #state{id = Now}}.
 

--- a/bench/src/member.erl
+++ b/bench/src/member.erl
@@ -62,7 +62,7 @@ init(Config) ->
 start_up_delay(Config) ->
     case proplists:get_value(start_up_delay, Config) of
         T when is_integer(T) ->
-            random:seed(erlang:now()),
+            random:seed(os:timestamp()),
             J = random:uniform(T),
             timer:sleep(T + J),
             ok;

--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -206,7 +206,7 @@ take_group_member(GroupName) ->
         Pools ->
             %% Put a random member at the front of the list and then
             %% return the first member you can walking the list.
-            {_, _, X} = erlang:now(),
+            {_, _, X} = os:timestamp(),
             Idx = (X rem length(Pools)) + 1,
             {PoolPid, Rest} = extract_nth(Idx, Pools),
             take_first_pool([PoolPid | Rest])


### PR DESCRIPTION
R18 deprecates erlang:now/0. Unfortunately, the new erlang:system_time or
the erlang:timestamp that is recommended is not available prior to R18. To
maintain a compatible codebase across both releases, os:timestamp/0 is the
way to go where monotonically increasing timestamp is not required.