### PR TITLE
Guard against passing wrong-typed argument instead of pid when calling return_group_member

### DIFF
--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -249,7 +249,7 @@ return_group_member(GroupName, MemberPid) ->
 -spec return_group_member(atom(), pid() | error_no_members, ok | fail) -> ok.
 return_group_member(_, error_no_members, _) ->
     ok;
-return_group_member(_GroupName, MemberPid, Status) ->
+return_group_member(_GroupName, MemberPid, Status) when is_pid(MemberPid) ->
     case ets:lookup(?POOLER_GROUP_TABLE, MemberPid) of
         [{MemberPid, PoolPid}] ->
             return_member(PoolPid, MemberPid, Status);

--- a/test/pooler_tests.erl
+++ b/test/pooler_tests.erl
@@ -481,6 +481,11 @@ pooler_groups_test_() ->
                ?assertEqual(ok, pooler:return_group_member(group_1, Pid))
        end},
 
+      {"return member with something which is not a pid",
+       fun() ->
+               ?assertException(error, _, pooler:return_group_member(group_1, not_pid))
+       end},
+
       {"take member from empty group",
        fun() ->
                %% artificially empty group member list


### PR DESCRIPTION
The lack of type guard for `MemberPid` argument in `return_group_member/3` function will result in returning `ok` even if the caller suppled wrong-typed argument. Also the `is_pid/1` guard of `return_group/3` which eventually must be called at the tail of `return_group_member/3`, could not catch this error because the case expression inside `return_group_member/3` which tries to find `MemberPid` in `?POOLER_GROUP_TABLE` matches the empty list and then returns `ok`.

I faced to this issue when I called `return_group_member/3` for releasing my Riak clients wrongly with `undefined` atom instead of its correct pid, and it always returns `ok`, so I couldn't find the root cause of the Riak client leak of my project.