### PR TITLE
Remove eunit header include from main pooler module

### DIFF
--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -12,8 +12,6 @@
 -behaviour(gen_server).
 
 -include("pooler.hrl").
--include_lib("eunit/include/eunit.hrl").
-
 
 %% type specs for pool metrics
 -type metric_value() :: 'unknown_pid' |


### PR DESCRIPTION
Including the eunit header defines TEST. Since the module conditionally
specifies `export_all` when TEST is defined, we were exporting
allthethings inadvertently all the time.