### PR TITLE
Terminating pooled children through supervisor

### DIFF
--- a/src/pooler.hrl
+++ b/src/pooler.hrl
@@ -5,8 +5,11 @@
 -define(DEFAULT_AUTO_GROW_THRESHOLD, undefined).
 -define(POOLER_GROUP_TABLE, pooler_group_table).
 -define(DEFAULT_POOLER_QUEUE_MAX, 50).
+-define(POOLER_POOL_NAME, '$pooler_pool_name').
 -define(POOLER_PID, '$pooler_pid').
--define(DEFAULT_STOP_MFA, {erlang, exit, [?POOLER_PID, kill]}).
+-define(DEFAULT_STOP_MFA, {supervisor,
+                           terminate_child,
+                           [?POOLER_POOL_NAME, ?POOLER_PID]}).
 
 -type member_info() :: {string(), free | pid(), {_, _, _}}.
 -type free_member_info() :: {string(), free, {_, _, _}}.

--- a/src/pooler_pool_sup.erl
+++ b/src/pooler_pool_sup.erl
@@ -4,7 +4,8 @@
 
 -export([start_link/1, init/1,
          pool_sup_name/1,
-         member_sup_name/1]).
+         member_sup_name/1,
+         build_member_sup_name/1]).
 
 -include("pooler.hrl").
 
@@ -25,8 +26,10 @@ init(#pool{} = Pool) ->
     Restart = {one_for_all, 5, 60},
     {ok, {Restart, [MemberSupSpec, PoolerSpec]}}.
 
-
 member_sup_name(#pool{name = PoolName}) ->
+    build_member_sup_name(PoolName).
+
+build_member_sup_name(PoolName) ->
     list_to_atom("pooler_" ++ atom_to_list(PoolName) ++ "_member_sup").
 
 pool_sup_name(#pool{name = PoolName}) ->

--- a/test/error_logger_mon.erl
+++ b/test/error_logger_mon.erl
@@ -1,0 +1,65 @@
+%%% A gen_server to check if we get any error_logger messages during test to see if
+%%% any messages gets generated when they shouldn't
+
+-module(error_logger_mon).
+
+-behaviour(gen_server).
+-define(SERVER, ?MODULE).
+
+-record(state, {count = 0 :: integer()}).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+%% gen_server
+-export([start_link/0,
+         report/0,
+         get_msg_count/0,
+         stop/0
+        ]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+report() ->
+    gen_server:call(?SERVER, report).
+
+get_msg_count() ->
+    gen_server:call(?SERVER, get_count).
+
+stop() ->
+    gen_server:call(?SERVER, stop).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+init([]) ->
+    {ok, #state{}}.
+
+handle_call(get_count, _From, #state{count = C} = State) ->
+    {reply, C, State};
+handle_call(report, _From, #state{count = C} = State) ->
+    {reply, ok, State#state{count = C+1}};
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, error, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/test/error_logger_pooler_h.erl
+++ b/test/error_logger_pooler_h.erl
@@ -1,0 +1,25 @@
+%%% report handler to add to error_logger for calling error_logger_mon
+%%% during test
+-module(error_logger_pooler_h).
+
+-export([init/1,
+	 handle_event/2,
+         handle_call/2,
+         handle_info/2,
+	 terminate/2]).
+
+init(T) ->
+    {ok, T}.
+
+handle_event(_Event, Type) ->
+    error_logger_mon:report(),
+    {ok, Type}.
+
+handle_info(_, Type) ->
+    {ok, Type}.
+
+handle_call(_Query, _Type) ->
+    {error, bad_query}.
+
+terminate(_Reason, _Type) ->
+    [].


### PR DESCRIPTION
By doing so the supervisor won't generate a error report through
error_logger which SASL picks up and generates a supervisor report.

Tests install a error_logger handler which keeps track of number of
messages during culling to make sure this behaviour is consistent in
future.

Travis is failing test cases on R15B03-1, which seems to be related to rebar3 mess (I'm guessing it's not loading paths correctly since it cannot find pooler:time_as_{millis, micro}/2). I'm a strong advocate of using build tools which are agnostic to what OTP version your system is running. A build tool shouldn't change behaviour depending on what target you're aiming for. 