### PR TITLE
Update erlang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: erlang
 otp_release:
-  - 18.0
-  - 17.0
+  - 21.0
+  - 20.3
+  - 19.3
+  - 18.3
+  - 17.5
   - R16B03
-  - R15B03
 script:
   - make test
+before_script:
+  - "kerl list installations"

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,8 @@
 {erl_opts, [
     {platform_define, "^[0-9]+", namespaced_types},
+    {platform_define, "^(19|2)", rand_only},
+    {platform_define, "^(R|1|20)", fun_stacktrace},
+
 
     debug_info,
 
@@ -35,9 +38,14 @@
 
         {deps, [
             {edown, ".*",
-                {git, "git://github.com/uwiger/edown.git", {tag, "0.8"}}}
-        ]}
-    ]}
+                {git, "https://github.com/uwiger/edown.git", {tag, "0.8"}}}
+        ]},
+        {erl_opts, [nowarn_export_all]}
+    ]},
+    {test, [
+        {erl_opts, [nowarn_export_all]}
+           ]
+    }
 ]}.
 
 {eunit_opts, [{report, {eunit_progress, [colored, profile]}}]}.

--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -743,7 +743,7 @@ remove_pid(Pid, Pool) ->
                        all_members = dict:erase(Pid, AllMembers)};
         error ->
             error_logger:error_report({{pool, PoolName}, unknown_pid, Pid,
-                                       erlang:get_stacktrace()}),
+                                       ?GET_STACKTRACE}),
             send_metric(Pool, events, unknown_pid, history),
             Pool
     end.

--- a/src/pooler.hrl
+++ b/src/pooler.hrl
@@ -24,6 +24,20 @@
 -type p_requestor_queue() :: queue().
 -endif.
 
+-ifdef(rand_only).
+-define(RANDOM_SEED(X), rand:seed(exs1024s, X)).
+-define(RANDOM_UNIFORM(X), rand:uniform(X)).
+-else.
+-define(RANDOM_SEED(X), random:seed(X)).
+-define(RANDOM_UNIFORM(X), random:uniform(X)).
+-endif.
+
+-ifdef(fun_stacktrace).
+-define(GET_STACKTRACE, erlang:get_stacktrace()).
+-else.
+-define(GET_STACKTRACE, try throw(fake_stacktrace) catch _:_:S -> S end).
+-endif.
+
 -record(pool, {
           name             :: atom(),
           group            :: atom(),

--- a/test/pooled_gs.erl
+++ b/test/pooled_gs.erl
@@ -10,6 +10,8 @@
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
 
+-include("pooler.hrl").
+
 %% ------------------------------------------------------------------
 %% API Function Exports
 %% ------------------------------------------------------------------
@@ -91,7 +93,7 @@ init({Type, StartFun}) ->
 handle_call(get_id, _From, State) ->
     {reply, {State#state.type, State#state.id}, State};
 handle_call({do_work, T}, _From, State) ->
-    Sleep = random:uniform(T),
+    Sleep = ?RANDOM_UNIFORM(T),
     timer:sleep(Sleep),
     {reply, {ok, Sleep}, State};
 handle_call(ping, _From, #state{ping_count = C } = State) ->

--- a/test/pooler_tests.erl
+++ b/test/pooler_tests.erl
@@ -769,7 +769,7 @@ sleep_for_configured_timeout() ->
                     _  ->
                         0
                 end,
-    timer:sleep(SleepTime).    
+    timer:sleep(SleepTime).
 
 pooler_integration_queueing_test_() ->
     {foreach,
@@ -1125,6 +1125,8 @@ no_error_logger_reports_after_culling_test_() ->
                ok = application:start(pooler),
                error_logger:add_report_handler(error_logger_pooler_h),
                Reason = monitor_members_trigger_culling_and_return_reason(),
+               %% we need to wait for the message to arrive before deleting handler
+               timer:sleep(250),
                error_logger:delete_report_handler(error_logger_pooler_h),
                ok = application:stop(pooler),
                ?assertEqual(killed, Reason),


### PR DESCRIPTION
    Support erlang through R21

    Update travis.yml to test R16-21. Drop R15 support (it's pretty old now),
    
    Minor cleanup to support the deprecations for Erlang 21.