### PR TITLE
Upgrade supported OTP versions; drop pg2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: ["26.0", "25.3", "24.3"]
+        otp: ["28.1", "27.3", "26.2", "25.3", "24.3"]
         os: ["ubuntu-22.04"]
-        include:
-          - otp: "23.3"
-            os: "ubuntu-20.04"
-          - otp: "22.3"
-            os: "ubuntu-20.04"
-          - otp: "21.3"
-            os: "ubuntu-20.04"
 
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +27,6 @@ jobs:
 
       - name: xref
         run: make xref
-        if: ${{ matrix.otp != '23.3' }}
 
       - name: Code formatter validation
         run: make format_check

--- a/.github/workflows/hot_upgrade.yml
+++ b/.github/workflows/hot_upgrade.yml
@@ -16,11 +16,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-20.04"]
-        otp: ["23.3"]
+        os: ["ubuntu-22.04"]
+        otp: ["27.3"]
         from_version:
             - "1.5.2"
-            - "9c28fb479f9329e2a1644565a632bc222780f1b7"
 
     steps:
       # This is to not have the git safe.directory failure

--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -1609,20 +1609,6 @@ config_as_map(Conf) when is_map(Conf) ->
 config_as_map(LegacyConf) when is_list(LegacyConf) ->
     maps:from_list(LegacyConf).
 
-% >= OTP-21
--ifdef(OTP_RELEASE).
--if(?OTP_RELEASE >= 23).
--define(USE_PG_NOT_PG2, true).
--else.
--undef(USE_PG_NOT_PG2).
--endif.
-% < OTP-21
--else.
--undef(USE_PG_NOT_PG2).
--endif.
-
--ifdef(USE_PG_NOT_PG2).
-
 pg_get_local_members(GroupName) ->
     pg:get_local_members(GroupName).
 
@@ -1637,25 +1623,3 @@ pg_join(Group, Pid) ->
 
 pg_leave(Group, Pid) ->
     pg:leave(Group, Pid).
-
--else.
-
-pg_get_local_members(GroupName) ->
-    case pg2:get_local_members(GroupName) of
-        {error, {no_such_group, GroupName}} -> [];
-        Pids -> Pids
-    end.
-
-pg_delete(GroupName) ->
-    pg2:delete(GroupName).
-
-pg_create(Group) ->
-    pg2:create(Group).
-
-pg_join(Group, Pid) ->
-    pg2:join(Group, Pid).
-
-pg_leave(Group, Pid) ->
-    pg2:leave(Group, Pid).
-
--endif.

--- a/test/hotupgrade_test.sh
+++ b/test/hotupgrade_test.sh
@@ -55,7 +55,9 @@ do_check() {
         echo $RES2 >&2
         exit 1
     fi
-    ./_build/test/rel/pooler_test/bin/pooler_test stop
+    ./_build/test/rel/pooler_test/bin/pooler_test versions
+    # ./_build/test/rel/pooler_test/bin/pooler_test stop  # hangs on GitHub Actions CI for some reason
+    ./_build/test/rel/pooler_test/bin/pooler_test eval 'init:stop().'
 }
 
 "do_$COMMAND"

--- a/test/pooler_tests.erl
+++ b/test/pooler_tests.erl
@@ -1671,20 +1671,6 @@ starting_members(PoolName) ->
 dump_pool(PoolName) ->
     gen_server:call(PoolName, dump_pool).
 
-% >= OTP-21
--ifdef(OTP_RELEASE).
--if(?OTP_RELEASE >= 23).
--define(USE_PG_NOT_PG2, true).
--else.
--undef(USE_PG_NOT_PG2).
--endif.
-% < OTP-21
--else.
--undef(USE_PG_NOT_PG2).
--endif.
-
--ifdef(USE_PG_NOT_PG2).
-
 pg_start() ->
     pg:start(_Scope = 'pg').
 
@@ -1696,16 +1682,3 @@ pg_stop() ->
 
 pg_leave(Group, Pid) ->
     pg:leave(Group, Pid).
-
--else.
-
-pg_start() ->
-    pg2:start().
-
-pg_stop() ->
-    application:stop(pg2).
-
-pg_leave(Group, Pid) ->
-    pg2:leave(Group, Pid).
-
--endif.

--- a/test/prop_pooler.erl
+++ b/test/prop_pooler.erl
@@ -413,10 +413,5 @@ pool_is_free(Pool, NumWorkers) ->
     ),
     true.
 
--if(?OTP_RELEASE >= 23).
 pg_start() ->
     pg:start(pg).
--else.
-pg_start() ->
-    pg2:start().
--endif.


### PR DESCRIPTION
* Add otp-27 and otp-28
* Drop otp older than otp-24
* Drop pg2 support since `pg` is available since otp-24