### PR TITLE
Initialize mfa

### DIFF
--- a/README.org
+++ b/README.org
@@ -114,10 +114,9 @@ and one pool talking to a Postgresql database:
                       start_mfa =>
                        {epgsql, connect, [#{host => "localhost", username => "user", database => "base"}]}}
                    ]}
-             %% if you want to enable metrics, set this to a module with
-             %% an API conformant to the folsom_metrics module.
-             %% If this config is missing, then no metrics are sent.
-             %% {metrics_module, folsom_metrics}
+             %% optional: enable metrics via folsom or exometer
+             %% metrics_mod => folsom_metrics,
+             %% metrics_api => folsom
           ]}
   ].
 #+END_SRC
@@ -156,6 +155,96 @@ During a check, pool members that have not been used in more than
 The default value for =cull_interval= is ={1, min}=. You can disable
 culling by specifying a value os ={0, min}=. The =max_age= parameter
 defaults to ={30, sec}=.
+
+**** Member start timeout (member_start_timeout)
+
+The =member_start_timeout= parameter sets how long pooler will wait for a
+member to be started before giving up on it.  If a starter process takes longer
+than this, the starter is killed and the partially-started member is discarded.
+The value is a =time_spec()= tuple; the default is ={1, min}=.
+
+#+BEGIN_SRC erlang
+#{member_start_timeout => {30, sec}}
+#+END_SRC
+
+**** Request queue limit (queue_max)
+
+When all pool members are in use, =take_member= calls are queued up to
+=queue_max= entries (default =50=).  Callers beyond this limit receive
+=error_no_members= immediately rather than waiting.  Set it to =0= to disable
+queuing entirely.
+
+#+BEGIN_SRC erlang
+#{queue_max => 100}
+#+END_SRC
+
+**** Proactive growth (auto_grow_threshold)
+
+By default, pooler only starts new members on demand — when a consumer calls
+=take_member= and the pool is exhausted.  Setting =auto_grow_threshold= to a
+non-negative integer causes pooler to start a new member proactively whenever
+the number of in-use members exceeds the threshold.  This can help keep latency
+low by warming up spare capacity before the pool is fully exhausted.  Disabled
+by default (=undefined=).
+
+This option only has an effect on dynamic-sized pools (i.e. =max_count= >
+=init_count=); in a fixed-size pool there are no spare slots to grow into.
+
+#+BEGIN_SRC erlang
+#{init_count => 5,
+  max_count => 20,
+  auto_grow_threshold => 8}   %% start a new member when 9+ are in use
+#+END_SRC
+
+**** Custom member initialization (initialize_mfa)
+
+The =initialize_mfa= pool configuration parameter allows you to run custom
+initialization logic after a member process has been started but before it is
+made available to consumers.  This is useful when the member's =start_link=
+returns quickly (so the supervisor is not blocked) but some slow work — such as
+a TCP handshake or a database login — still needs to happen before the member
+is safe to use.
+
+The value is an ={M, F, A}= tuple.  Before calling, pooler replaces the atom
+='$pooler_pid'= anywhere in =A= with the pid of the newly started member, so
+you can pass the pid to your callback without hard-coding it:
+
+#+BEGIN_SRC erlang
+#{name => pg_pool,
+  max_count => 10,
+  init_count => 2,
+  start_mfa => {my_conn, start_link, []},
+  initialize_mfa => {my_conn, handshake, ['$pooler_pid']}}
+#+END_SRC
+
+The callback must return =ok= on success.  If it returns ={error, Reason}=,
+raises an exception, or the member process dies during initialization, the
+member is terminated and never added to the pool.  Pooler will log an error but
+will not retry; the pool simply starts with fewer members than =init_count=
+until the next growth event.
+
+The option is also accepted by =pooler:pool_reconfigure/2=.
+
+**** Custom member termination (stop_mfa)
+
+By default, pooler removes a pool member by calling
+=supervisor:terminate_child/2=, which is a synchronous call to the member
+supervisor.  If your members perform slow teardown (e.g. sending a goodbye
+frame over a network connection), this can block the pool gen_server while the
+supervisor is busy.
+
+The =stop_mfa= pool configuration parameter lets you override this.  It follows
+the same ={M, F, A}= convention with the ='$pooler_pid'= placeholder:
+
+#+BEGIN_SRC erlang
+#{name => pg_pool,
+  ...
+  stop_mfa => {my_conn, close, ['$pooler_pid']}}
+#+END_SRC
+
+The callback is called instead of =supervisor:terminate_child/2=.  If you want
+teardown to be fully asynchronous (fire-and-forget), make your callback send a
+message rather than blocking.
 
 *** Pool Configuration via =pooler:new_pool=
 You can create pools using =pooler:new_pool/1= when accepts a
@@ -252,11 +341,22 @@ PoolerSup = {pooler_sup, {pooler_sup, start_link, []},
 #+END_SRC
 
 *** Metrics
-You can enable metrics collection by adding a =metrics_module= entry
-to pooler's app config. Metrics are disabled by default. The module
-specified must have an API matching that of the [[https://github.com/boundary/folsom/blob/master/src/folsom_metrics.erl][folsom_metrics]] module
-in [[https://github.com/boundary/folsom][folsom]] (to use folsom, specify ={metrics_module, folsom_metrics}}=
-and ensure that folsom is in your code path and has been started.
+You can enable metrics collection by setting =metrics_mod= and =metrics_api= in
+the pool config (or the =pooler= application environment).  Metrics are
+disabled by default.
+
+=metrics_api= selects the backend API: =folsom= (default when =metrics_mod= is
+set) or =exometer=.  =metrics_mod= is the module that implements the chosen API
+— e.g. =folsom_metrics= for folsom, or a custom module with a compatible interface.
+
+#+BEGIN_SRC erlang
+#{name => my_pool,
+  ...,
+  metrics_mod => folsom_metrics,
+  metrics_api => folsom}
+#+END_SRC
+
+Ensure the metrics library is in your code path and has been started before pooler.
 
 When enabled, the following metrics will be tracked:
 

--- a/README.org
+++ b/README.org
@@ -205,9 +205,10 @@ returns quickly (so the supervisor is not blocked) but some slow work — such a
 a TCP handshake or a database login — still needs to happen before the member
 is safe to use.
 
-The value is an ={M, F, A}= tuple.  Before calling, pooler replaces the atom
-='$pooler_pid'= anywhere in =A= with the pid of the newly started member, so
-you can pass the pid to your callback without hard-coding it:
+The value is an ={M, F, A}= tuple.  Before calling, pooler replaces placeholder
+atoms in =A=: ='$pooler_pid'= with the pid of the newly started member, and
+='$pooler_pool_name'= with the member supervisor name for the pool (same
+placeholders supported by =stop_mfa=):
 
 #+BEGIN_SRC erlang
 #{name => pg_pool,

--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -146,6 +146,14 @@
     %% The list of arguments must contain the fixed atom '$pooler_pid'.
     stop_mfa = ?DEFAULT_STOP_MFA :: {atom(), atom(), [term()]},
 
+    %% Optional callback invoked by pooler_starter after supervisor:start_child
+    %% returns but before the member is accepted into the pool. Use this to
+    %% perform slow initialization (e.g. a network handshake) outside the
+    %% member supervisor, so concurrent starts do not serialize through it.
+    %% Arguments may contain the placeholder '$pooler_pid'.
+    %% Must return 'ok' on success or '{error, Reason}' on failure.
+    initialize_mfa = undefined :: undefined | {atom(), atom(), [term()]},
+
     %% The module to use for collecting metrics. If set to
     %% 'pooler_no_metrics', then metric sending calls do
     %% nothing. A typical value to actually capture metrics is
@@ -184,6 +192,7 @@
         metrics_api => folsom | exometer,
         metrics_mod => module(),
         stop_mfa => {module(), atom(), ['$pooler_pid' | any(), ...]},
+        initialize_mfa => {module(), atom(), ['$pooler_pid' | any(), ...]},
         auto_grow_threshold => non_neg_integer(),
         add_member_retry => non_neg_integer()
     }.
@@ -211,6 +220,7 @@
         | {metrics_api, folsom | exometer}
         | {metrics_mod, module()}
         | {stop_mfa, {module(), atom(), ['$pooler_pid' | any(), ...]}}
+        | {initialize_mfa, undefined | {module(), atom(), ['$pooler_pid' | any(), ...]}}
         | {auto_grow_threshold, non_neg_integer()}}.
 
 -type free_member_info() :: {reference(), free, erlang:timestamp()}.
@@ -567,6 +577,7 @@ init(#{name := Name, max_count := MaxCount, init_count := InitCount, start_mfa :
         member_start_timeout = maps:get(member_start_timeout, P, ?DEFAULT_MEMBER_START_TIMEOUT),
         auto_grow_threshold = maps:get(auto_grow_threshold, P, ?DEFAULT_AUTO_GROW_THRESHOLD),
         stop_mfa = maps:get(stop_mfa, P, ?DEFAULT_STOP_MFA),
+        initialize_mfa = maps:get(initialize_mfa, P, undefined),
         metrics_mod = maps:get(metrics_mod, P, pooler_no_metrics),
         metrics_api = maps:get(metrics_api, P, folsom),
         queue_max = maps:get(queue_max, P, ?DEFAULT_POOLER_QUEUE_MAX)
@@ -864,11 +875,11 @@ accumulate_starting_member_not_stale(Pool, Now, SM = {Pid, StartTime}, MaxAgeSec
             AccIn
     end.
 
-init_members_sync(N, #pool{name = PoolName, member_sup = MemberSup} = Pool) ->
+init_members_sync(N, #pool{name = PoolName, member_sup = MemberSup, initialize_mfa = InitMFA} = Pool) ->
     Self = self(),
     StartTime = os:timestamp(),
     StartRefs = [
-        {pooler_starter:start_member(PoolName, MemberSup, Self), StartTime}
+        {pooler_starter:start_member(PoolName, MemberSup, Self, InitMFA), StartTime}
      || _I <- lists:seq(1, N)
     ],
     Pool1 = Pool#pool{starting_members = StartRefs},
@@ -987,10 +998,13 @@ take_member_from_pool_queued(
 %% @doc Add `Count' members to `Pool' asynchronously. Returns updated
 %% `Pool' record with starting member refs added to field
 %% `starting_members'.
-add_members_async(Count, #pool{name = PoolName, member_sup = MemberSup, starting_members = StartingMembers} = Pool) ->
+add_members_async(
+    Count,
+    #pool{name = PoolName, member_sup = MemberSup, starting_members = StartingMembers, initialize_mfa = InitMFA} = Pool
+) ->
     StartTime = os:timestamp(),
     StartRefs = [
-        {pooler_starter:start_member(PoolName, MemberSup), StartTime}
+        {pooler_starter:start_member(PoolName, MemberSup, InitMFA), StartTime}
      || _I <- lists:seq(1, Count)
     ],
     Pool#pool{starting_members = StartRefs ++ StartingMembers}.
@@ -1248,6 +1262,7 @@ calculate_reconfigure_actions(
         member_start_timeout => ?DEFAULT_MEMBER_START_TIMEOUT,
         auto_grow_threshold => ?DEFAULT_AUTO_GROW_THRESHOLD,
         stop_mfa => ?DEFAULT_STOP_MFA,
+        initialize_mfa => undefined,
         metrics_mod => pooler_no_metrics,
         metrics_api => folsom,
         queue_max => ?DEFAULT_POOLER_QUEUE_MAX
@@ -1269,6 +1284,7 @@ calculate_reconfigure_actions(
                 metrics_api,
                 metrics_mod,
                 stop_mfa,
+                initialize_mfa,
                 auto_grow_threshold
             ]
         )
@@ -1367,6 +1383,8 @@ mk_rec_action(metrics_mod = P, New, _, #pool{metrics_mod = Old}) when New =/= Ol
     [{set_parameter, {P, New}}];
 mk_rec_action(stop_mfa = P, New, _, #pool{stop_mfa = Old}) when New =/= Old ->
     [{set_parameter, {P, New}}];
+mk_rec_action(initialize_mfa = P, New, _, #pool{initialize_mfa = Old}) when New =/= Old ->
+    [{set_parameter, {P, New}}];
 mk_rec_action(auto_grow_threshold = P, New, _, #pool{auto_grow_threshold = Old}) when New =/= Old ->
     [{set_parameter, {P, New}}];
 mk_rec_action(_Param, _NewVal, _, _Pool) ->
@@ -1420,6 +1438,8 @@ set_parameter(metrics_mod, Value, Pool) ->
     Pool#pool{metrics_mod = Value};
 set_parameter(stop_mfa, Value, Pool) ->
     Pool#pool{stop_mfa = Value};
+set_parameter(initialize_mfa, Value, Pool) ->
+    Pool#pool{initialize_mfa = Value};
 set_parameter(auto_grow_threshold, Value, Pool) ->
     Pool#pool{auto_grow_threshold = Value}.
 

--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -75,9 +75,7 @@
 -define(DEFAULT_AUTO_GROW_THRESHOLD, undefined).
 -define(POOLER_GROUP_TABLE, pooler_group_table).
 -define(DEFAULT_POOLER_QUEUE_MAX, 50).
--define(POOLER_POOL_NAME, '$pooler_pool_name').
--define(POOLER_PID, '$pooler_pid').
--define(DEFAULT_STOP_MFA, {supervisor, terminate_child, [?POOLER_POOL_NAME, ?POOLER_PID]}).
+-define(DEFAULT_STOP_MFA, {supervisor, terminate_child, ['$pooler_pool_name', '$pooler_pid']}).
 
 -record(pool, {
     name :: atom(),
@@ -150,7 +148,7 @@
     %% returns but before the member is accepted into the pool. Use this to
     %% perform slow initialization (e.g. a network handshake) outside the
     %% member supervisor, so concurrent starts do not serialize through it.
-    %% Arguments may contain the placeholder '$pooler_pid'.
+    %% Arguments may contain the placeholders '$pooler_pid' and '$pooler_pool_name'.
     %% Must return 'ok' on success or '{error, Reason}' on failure.
     initialize_mfa = undefined :: undefined | {atom(), atom(), [term()]},
 
@@ -192,7 +190,7 @@
         metrics_api => folsom | exometer,
         metrics_mod => module(),
         stop_mfa => {module(), atom(), ['$pooler_pid' | any(), ...]},
-        initialize_mfa => {module(), atom(), ['$pooler_pid' | any(), ...]},
+        initialize_mfa => {module(), atom(), ['$pooler_pid' | '$pooler_pool_name' | any(), ...]},
         auto_grow_threshold => non_neg_integer(),
         add_member_retry => non_neg_integer()
     }.
@@ -220,7 +218,7 @@
         | {metrics_api, folsom | exometer}
         | {metrics_mod, module()}
         | {stop_mfa, {module(), atom(), ['$pooler_pid' | any(), ...]}}
-        | {initialize_mfa, undefined | {module(), atom(), ['$pooler_pid' | any(), ...]}}
+        | {initialize_mfa, undefined | {module(), atom(), ['$pooler_pid' | '$pooler_pool_name' | any(), ...]}}
         | {auto_grow_threshold, non_neg_integer()}}.
 
 -type free_member_info() :: {reference(), free, erlang:timestamp()}.
@@ -1565,26 +1563,12 @@ maybe_reply({Member, NewPool}) ->
 %% default callback.
 -spec terminate_pid(atom(), pid(), {atom(), atom(), [term()]}) -> ok.
 terminate_pid(PoolName, Pid, {Mod, Fun, Args}) when is_list(Args) ->
-    NewArgs = replace_placeholders(PoolName, Pid, Args),
-    case catch erlang:apply(Mod, Fun, NewArgs) of
-        {'EXIT', _} ->
-            terminate_pid(PoolName, Pid, ?DEFAULT_STOP_MFA);
-        _Result ->
-            ok
+    NewArgs = pooler_starter:replace_placeholders(PoolName, Pid, Args),
+    try erlang:apply(Mod, Fun, NewArgs) of
+        _ -> ok
+    catch
+        _:_ -> terminate_pid(PoolName, Pid, ?DEFAULT_STOP_MFA)
     end.
-
-replace_placeholders(Name, Pid, Args) ->
-    [
-        case Arg of
-            ?POOLER_POOL_NAME ->
-                pooler_pool_sup:build_member_sup_name(Name);
-            ?POOLER_PID ->
-                Pid;
-            _ ->
-                Arg
-        end
-     || Arg <- Args
-    ].
 
 compute_utilization(#pool{
     max_count = MaxCount,

--- a/src/pooler_pool_sup.erl
+++ b/src/pooler_pool_sup.erl
@@ -58,6 +58,7 @@ init(PoolRecord) when is_tuple(PoolRecord), element(1, PoolRecord) =:= pool ->
                 metrics_api,
                 metrics_mod,
                 stop_mfa,
+                initialize_mfa,
                 auto_grow_threshold,
                 add_member_retry,
                 metrics_mod,

--- a/src/pooler_starter.erl
+++ b/src/pooler_starter.erl
@@ -164,6 +164,15 @@ do_start_member(PoolSup, PoolName, InitMFA) ->
                 ok ->
                     {self(), Pid};
                 Error ->
+                    ?LOG_ERROR(
+                        #{
+                            label => "failed to initialize member",
+                            pool => PoolName,
+                            pid => Pid,
+                            error => Error
+                        },
+                        #{domain => [pooler]}
+                    ),
                     supervisor:terminate_child(PoolSup, Pid),
                     {self(), Error}
             end;

--- a/src/pooler_starter.erl
+++ b/src/pooler_starter.erl
@@ -7,6 +7,9 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-define(POOLER_POOL_NAME, '$pooler_pool_name').
+-define(POOLER_PID, '$pooler_pid').
+
 %% ------------------------------------------------------------------
 %% API Function Exports
 %% ------------------------------------------------------------------
@@ -17,7 +20,8 @@
     start_member/3,
     start_member/4,
     stop_member_async/1,
-    stop/1
+    stop/1,
+    replace_placeholders/3
 ]).
 
 %% ------------------------------------------------------------------
@@ -156,7 +160,7 @@ code_change(_OldVsn, State, _Extra) ->
 do_start_member(PoolSup, PoolName, InitMFA) ->
     case supervisor:start_child(PoolSup, []) of
         {ok, Pid} ->
-            case call_initialize_mfa(Pid, InitMFA) of
+            case call_initialize_mfa(PoolName, Pid, InitMFA) of
                 ok ->
                     {self(), Pid};
                 Error ->
@@ -175,22 +179,28 @@ do_start_member(PoolSup, PoolName, InitMFA) ->
             {self(), Error}
     end.
 
--spec call_initialize_mfa(pid(), initialize_mfa()) -> ok | {error, term()}.
-call_initialize_mfa(_Pid, undefined) ->
-    ok;
-call_initialize_mfa(Pid, {Mod, Fun, Args}) ->
-    NewArgs = [
-        case A of
-            '$pooler_pid' -> Pid;
-            _ -> A
+-spec replace_placeholders(pooler:pool_name(), pid(), [term()]) -> [term()].
+replace_placeholders(PoolName, Pid, Args) ->
+    [
+        case Arg of
+            ?POOLER_POOL_NAME -> pooler_pool_sup:build_member_sup_name(PoolName);
+            ?POOLER_PID -> Pid;
+            _ -> Arg
         end
-     || A <- Args
-    ],
-    case catch erlang:apply(Mod, Fun, NewArgs) of
+     || Arg <- Args
+    ].
+
+-spec call_initialize_mfa(pooler:pool_name(), pid(), initialize_mfa()) -> ok | {error, term()}.
+call_initialize_mfa(_PoolName, _Pid, undefined) ->
+    ok;
+call_initialize_mfa(PoolName, Pid, {Mod, Fun, Args}) ->
+    NewArgs = replace_placeholders(PoolName, Pid, Args),
+    try erlang:apply(Mod, Fun, NewArgs) of
         ok -> ok;
         {error, _} = Err -> Err;
-        {'EXIT', Reason} -> {error, {initialize_mfa_exit, Reason}};
         Other -> {error, {unexpected_initialize_mfa_return, Other}}
+    catch
+        _:Reason -> {error, {initialize_mfa_exit, Reason}}
     end.
 
 -spec send_accept_member(parent(), pooler:pool_name(), start_result()) -> ok.

--- a/src/pooler_starter.erl
+++ b/src/pooler_starter.erl
@@ -15,6 +15,7 @@
     start_link/1,
     start_member/2,
     start_member/3,
+    start_member/4,
     stop_member_async/1,
     stop/1
 ]).
@@ -37,15 +38,16 @@
 
 -type pool_member_sup() :: pid() | atom().
 -type parent() :: pid() | pool.
+-type initialize_mfa() :: undefined | {module(), atom(), [term()]}.
 -type start_result() :: {StarterPid :: pid(), Result :: pid() | {error, _}}.
--opaque start_spec() :: {pooler:pool_name(), pool_member_sup(), parent()}.
+-opaque start_spec() :: {pooler:pool_name(), pool_member_sup(), parent(), initialize_mfa()}.
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
 -spec start_link(start_spec()) -> {ok, pid()}.
-start_link({_, _, _} = Spec) ->
+start_link({_, _, _, _} = Spec) ->
     gen_server:start_link(?MODULE, Spec, []).
 
 stop(Starter) ->
@@ -63,10 +65,14 @@ stop(Starter) ->
 %% creating a single member.
 -spec start_member(pooler:pool_name(), pool_member_sup()) -> pid().
 start_member(PoolName, PoolMemberSup) ->
-    {ok, Pid} = pooler_starter_sup:new_starter({PoolName, PoolMemberSup, pool}),
+    start_member(PoolName, PoolMemberSup, undefined).
+
+-spec start_member(pooler:pool_name(), pool_member_sup(), initialize_mfa()) -> pid().
+start_member(PoolName, PoolMemberSup, InitMFA) ->
+    {ok, Pid} = pooler_starter_sup:new_starter({PoolName, PoolMemberSup, pool, InitMFA}),
     Pid.
 
-%% @doc Same as {@link start_member/1} except that instead of calling
+%% @doc Same as {@link start_member/2} except that instead of calling
 %% {@link pooler:accept_member/2} a raw message is sent to `Parent' of
 %% the form `{accept_member, {Ref, Member}'. Where `Member' will
 %% either be the member pid or an error term and `Ref' will be the
@@ -74,9 +80,9 @@ start_member(PoolName, PoolMemberSup) ->
 %%
 %% This is used by the init function in the `pooler' to start the
 %% initial set of pool members in parallel.
--spec start_member(pooler:pool_name(), pool_member_sup(), pid()) -> pid().
-start_member(PoolName, PoolMemberSup, Parent) ->
-    {ok, Pid} = pooler_starter_sup:new_starter({PoolName, PoolMemberSup, Parent}),
+-spec start_member(pooler:pool_name(), pool_member_sup(), pid(), initialize_mfa()) -> pid().
+start_member(PoolName, PoolMemberSup, Parent, InitMFA) ->
+    {ok, Pid} = pooler_starter_sup:new_starter({PoolName, PoolMemberSup, Parent, InitMFA}),
     Pid.
 
 %% @doc Stop a member in the pool
@@ -96,18 +102,20 @@ stop_member_async(Pid) ->
     parent :: parent(),
     pool_name :: pooler:pool_name(),
     pool_member_sup :: pool_member_sup(),
+    initialize_mfa :: initialize_mfa(),
     msg :: start_result() | undefined
 }).
 
 -spec init(start_spec()) -> {ok, #starter{}, {continue, start}}.
-init({PoolName, PoolMemberSup, Parent}) ->
-    {ok, #starter{pool_name = PoolName, pool_member_sup = PoolMemberSup, parent = Parent}, {continue, start}}.
+init({PoolName, PoolMemberSup, Parent, InitMFA}) ->
+    {ok, #starter{pool_name = PoolName, pool_member_sup = PoolMemberSup, parent = Parent, initialize_mfa = InitMFA},
+        {continue, start}}.
 
 handle_continue(
     start,
-    #starter{pool_member_sup = PoolSup, pool_name = PoolName} = State
+    #starter{pool_member_sup = PoolSup, pool_name = PoolName, initialize_mfa = InitMFA} = State
 ) ->
-    Msg = do_start_member(PoolSup, PoolName),
+    Msg = do_start_member(PoolSup, PoolName, InitMFA),
     % asynchronously in order to receive potential `stop*'
     accept_member_async(self()),
     {noreply, State#starter{msg = Msg}}.
@@ -115,10 +123,13 @@ handle_continue(
 handle_call(_Request, _From, State) ->
     {noreply, State}.
 
-handle_cast(stop_member, #starter{msg = {_Me, Pid}, pool_member_sup = MemberSup} = State) ->
+handle_cast(stop_member, #starter{msg = {_Me, Pid}, pool_member_sup = MemberSup} = State) when is_pid(Pid) ->
     %% The process we were starting is no longer valid for the pool.
     %% Cleanup the process and stop normally.
     supervisor:terminate_child(MemberSup, Pid),
+    {stop, normal, State};
+handle_cast(stop_member, State) ->
+    %% Either init failed (msg is an error) or start_member hasn't completed yet.
     {stop, normal, State};
 handle_cast(accept_member, #starter{msg = Msg, parent = Parent, pool_name = PoolName} = State) ->
     %% Process creation has succeeded. Send the member to the pooler
@@ -142,10 +153,16 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-do_start_member(PoolSup, PoolName) ->
+do_start_member(PoolSup, PoolName, InitMFA) ->
     case supervisor:start_child(PoolSup, []) of
         {ok, Pid} ->
-            {self(), Pid};
+            case call_initialize_mfa(Pid, InitMFA) of
+                ok ->
+                    {self(), Pid};
+                Error ->
+                    supervisor:terminate_child(PoolSup, Pid),
+                    {self(), Error}
+            end;
         Error ->
             ?LOG_ERROR(
                 #{
@@ -156,6 +173,24 @@ do_start_member(PoolSup, PoolName) ->
                 #{domain => [pooler]}
             ),
             {self(), Error}
+    end.
+
+-spec call_initialize_mfa(pid(), initialize_mfa()) -> ok | {error, term()}.
+call_initialize_mfa(_Pid, undefined) ->
+    ok;
+call_initialize_mfa(Pid, {Mod, Fun, Args}) ->
+    NewArgs = [
+        case A of
+            '$pooler_pid' -> Pid;
+            _ -> A
+        end
+     || A <- Args
+    ],
+    case catch erlang:apply(Mod, Fun, NewArgs) of
+        ok -> ok;
+        {error, _} = Err -> Err;
+        {'EXIT', Reason} -> {error, {initialize_mfa_exit, Reason}};
+        Other -> {error, {unexpected_initialize_mfa_return, Other}}
     end.
 
 -spec send_accept_member(parent(), pooler:pool_name(), start_result()) -> ok.

--- a/test/pooled_gs.erl
+++ b/test/pooled_gs.erl
@@ -22,7 +22,10 @@
     crash/1,
     error_on_call/1,
     do_work/2,
-    stop/1
+    stop/1,
+    initialize/1,
+    initialize_fail/1,
+    initialize_crash/1
 ]).
 
 %% ------------------------------------------------------------------
@@ -76,6 +79,16 @@ error_on_call(S) ->
 
 stop(S) ->
     gen_server:call(S, stop).
+
+initialize(Pid) ->
+    pong = gen_server:call(Pid, ping),
+    ok.
+
+initialize_fail(_Pid) ->
+    {error, initialization_failed}.
+
+initialize_crash(_Pid) ->
+    erlang:error(initialization_crashed).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions

--- a/test/pooler_tests.erl
+++ b/test/pooler_tests.erl
@@ -1516,6 +1516,64 @@ reconfigure_test_() ->
             end}
         ]}.
 
+pooler_initialize_mfa_test_() ->
+    BasePool = #{
+        name => test_pool_1,
+        max_count => 3,
+        init_count => 2,
+        start_mfa => {pooled_gs, start_link, [{init_mfa_type}]}
+    },
+    {foreach, fun() -> ok end,
+        fun(_) ->
+            application:stop(pooler)
+        end,
+        [
+            {"members are usable when initialize_mfa succeeds", fun() ->
+                ok = pooler:start(),
+                pooler:new_pool(BasePool#{
+                    initialize_mfa => {pooled_gs, initialize, ['$pooler_pid']}
+                }),
+                Pid = pooler:take_member(test_pool_1),
+                ?assertNotEqual(error_no_members, Pid),
+                ?assertEqual(pong, pooled_gs:ping(Pid)),
+                pooler:return_member(test_pool_1, Pid)
+            end},
+            {"member is not accepted when initialize_mfa returns error", fun() ->
+                ok = pooler:start(),
+                pooler:new_pool(BasePool#{
+                    initialize_mfa => {pooled_gs, initialize_fail, ['$pooler_pid']}
+                }),
+                ?assertEqual(error_no_members, pooler:take_member(test_pool_1))
+            end},
+            {"member is not accepted when initialize_mfa raises an exception", fun() ->
+                ok = pooler:start(),
+                pooler:new_pool(BasePool#{
+                    initialize_mfa => {pooled_gs, initialize_crash, ['$pooler_pid']}
+                }),
+                ?assertEqual(error_no_members, pooler:take_member(test_pool_1))
+            end},
+            {"member is not accepted when initialize_mfa kills the worker", fun() ->
+                ok = pooler:start(),
+                pooler:new_pool(BasePool#{
+                    initialize_mfa => {pooled_gs, error_on_call, ['$pooler_pid']}
+                }),
+                ?assertEqual(error_no_members, pooler:take_member(test_pool_1))
+            end},
+            {"initialize_mfa can be updated via pool_reconfigure", fun() ->
+                ok = pooler:start(),
+                pooler:new_pool(BasePool),
+                InitMFA = {pooled_gs, initialize, ['$pooler_pid']},
+                {ok, Actions} = pooler:pool_reconfigure(test_pool_1, BasePool#{
+                    initialize_mfa => InitMFA
+                }),
+                ?assertEqual([{set_parameter, {initialize_mfa, InitMFA}}], Actions),
+                ?assertMatch(
+                    #{initialize_mfa := InitMFA},
+                    gen_server:call(test_pool_1, dump_pool)
+                )
+            end}
+        ]}.
+
 wait_for_dump(Pool, Timeout, Fun) when Timeout > 0 ->
     Dump = gen_server:call(Pool, dump_pool),
     case Fun(Dump) of


### PR DESCRIPTION
This should add a workaround for #104

For example, instead of calling `epgsql:connect(Opts)` one could use:

```erlang
{start_mfa, {epgsqla, start_link, []},
{initialize_mfa, {epgsql, connect, ['$pooler_pid', "host", "username", "password", #{..}]} % connect/5 doesn't start process
```

It will start an empty epgsql process under supervisor and then performs a slow initialization outside of supervisor; uninitialized process won't make it to the pool, but it will release the single-process supervisor bottleneck.

I ran benchmarks vs master and there were no real changes.