### PR TITLE
Async stop

### DIFF
--- a/README.org
+++ b/README.org
@@ -361,12 +361,13 @@ Ensure the metrics library is in your code path and has been started before pool
 
 When enabled, the following metrics will be tracked:
 
-| Metric Label                  | Description                                                                 |
-| pooler.POOL_NAME.take_rate    | meter recording rate at which take_member is called                         |
-| pooler.error_no_members_count | counter indicating how many times take_member has returned error_no_members |
-| pooler.killed_free_count      | counter how many members have been killed when in the free state            |
-| pooler.killed_in_use_count    | counter how many members have been killed when in the in_use state          |
-| pooler.event                  | history various error conditions                                            |
+| Metric Label                       | Description                                                                 |
+| pooler.POOL_NAME.take_rate         | meter recording rate at which take_member is called                         |
+| pooler.POOL_NAME.stopping_count    | histogram tracking number of members currently being stopped asynchronously |
+| pooler.error_no_members_count      | counter indicating how many times take_member has returned error_no_members |
+| pooler.killed_free_count           | counter how many members have been killed when in the free state            |
+| pooler.killed_in_use_count         | counter how many members have been killed when in the in_use state          |
+| pooler.event                       | history various error conditions                                            |
 
 *** Demo Quick Start
 

--- a/README.org
+++ b/README.org
@@ -9,42 +9,34 @@ with exclusive access to pool members using =pooler:take_member=.
 
 ** What pooler does
 
-*** Protects the members of a pool from being used concurrently
+- *Exclusive member access* — each consumer gets sole ownership of a member for the duration of its work; pooler monitors consumers and reclaims members automatically on exit
+- *Fixed and dynamic sizing* — pools grow on demand up to =max_count= and cull idle members back to =init_count= on a configurable schedule
+- *Blocked-caller queuing* — =take_member/2= queues callers with a timeout instead of immediately returning =error_no_members= when the pool is busy
+- *Responsive under slow workers* — member starts and stops run in supervised helper processes, never blocking the pool gen-server
+- *Survives service outages* — returns =error_no_members= during outages without risking a supervisor restart cascade
+- *Group pools and load balancing* — pools can be grouped for random-selection load balancing across backends
+- *Fully supervised* — every process (members, starters, stoppers) lives under a supervision tree; shutting down a pool cleanly terminates all associated processes with no orphans
+- *Observability* — utilization stats, pool metrics, and structured logging
 
-The main pooler interface is =pooler:take_member/1= and
-=pooler:return_member/3=.  The pooler server will keep track of which
-members are *in use* and which are *free*.  There is no need to call
-=pooler:return_member= if the consumer is a short-lived process; in
-this case, pooler will detect the consumer's normal exit and reclaim
-the member.  To achieve this, pooler tracks the calling process of
-=take_member= as the consumer of the pool member.  Thus pooler assumes
-that there is no middle-man process calling =take_member= and handing
-out the member pid to another worker process.
+*** Exclusive member access
 
-*** Maintains the size of the pool
+Pooler monitors the *calling process* of =take_member= and uses that as the consumer identity, so =return_member= is optional for short-lived processes — pooler reclaims the member when the consumer exits.  This means the process that calls =take_member= must be the actual consumer; handing the member pid to a different process defeats the tracking mechanism.
 
-You specify an initial and a maximum number of members in the pool.
-Pooler will create new members on demand until the maximum member
-count is reached.  New pool members are added to replace members that
-crash.  If a consumer crashes, the member it was using will be
-destroyed and replaced.  You can configure Pooler to periodically
-check for and remove members that have not been used recently to
-reduce the member count back to its initial size.
+*** Pool sizing and member lifecycle
 
-*** Manage multiple pools
+Replacement is automatic: both a crashing member and an abnormally exiting consumer trigger destruction of the member and an async start of a replacement.  Culling runs on a configurable timer (=cull_interval=) to remove members idle longer than =max_age=, keeping resource usage proportional to actual demand.
 
-You can use pooler to manage multiple independent pools and multiple
-grouped pools. Independent pools allow you to pool clients for
-different backend services (e.g. postgresql and redis). Grouped pools
-can optionally be accessed using =pooler:take_group_member/1= to
-provide load balancing of the pools in the group. A typical use of
-grouped pools is to have each pool contain clients connected to a
-particular node in a cluster (think database read slaves).  Pooler's
-=take_group_member= function will randomly select a pool in the group
-to fetch a member from.  If the randomly selected pool has no free
-members, pooler will attempt to obtain a member from each pool in the
-group.  If there is no pool with available members, pooler will return
-=error_no_members=.
+*** Survives service outages
+
+When the backing service is unavailable, start attempts fail and =take_member= returns =error_no_members=, letting callers handle degradation gracefully.  The pool gen-server stays alive throughout and resumes filling the pool as soon as workers start succeeding again.  Repeated failures do not risk a supervisor restart cascade because workers use a =temporary= restart strategy.
+
+*** Keeps the pool gen-server responsive
+
+Member starts and stops are handled by short-lived supervised helper processes, so the pool gen-server never blocks on slow worker operations (e.g. TCP handshakes or protocol teardown).
+
+*** Group pools and load balancing
+
+Independent pools serve different backends within the same application.  Grouped pools sharing the same =group= tag form a cluster: =take_group_member= picks a pool at random and falls back to the remaining ones if the selected pool has no free members.  A typical use is one pool per node in a database read-replica set.
 
 ** Motivation
 
@@ -182,10 +174,11 @@ queuing entirely.
 
 By default, pooler only starts new members on demand — when a consumer calls
 =take_member= and the pool is exhausted.  Setting =auto_grow_threshold= to a
-non-negative integer causes pooler to start a new member proactively whenever
-the number of in-use members exceeds the threshold.  This can help keep latency
-low by warming up spare capacity before the pool is fully exhausted.  Disabled
-by default (=undefined=).
+non-negative integer causes pooler to start new members proactively after each
+successful =take_member= if the remaining free count has dropped to or below the
+threshold.  The new starts are capped at =max_count= total.  This can help keep
+latency low by warming up spare capacity before the pool is fully exhausted.
+Disabled by default (=undefined=).
 
 This option only has an effect on dynamic-sized pools (i.e. =max_count= >
 =init_count=); in a fixed-size pool there are no spare slots to grow into.
@@ -193,7 +186,7 @@ This option only has an effect on dynamic-sized pools (i.e. =max_count= >
 #+BEGIN_SRC erlang
 #{init_count => 5,
   max_count => 20,
-  auto_grow_threshold => 8}   %% start a new member when 9+ are in use
+  auto_grow_threshold => 2}   %% start new members when free_count drops to 2
 #+END_SRC
 
 **** Custom member initialization (initialize_mfa)
@@ -229,13 +222,13 @@ The option is also accepted by =pooler:pool_reconfigure/2=.
 **** Custom member termination (stop_mfa)
 
 By default, pooler removes a pool member by calling
-=supervisor:terminate_child/2=, which is a synchronous call to the member
-supervisor.  If your members perform slow teardown (e.g. sending a goodbye
-frame over a network connection), this can block the pool gen_server while the
-supervisor is busy.
+=supervisor:terminate_child/2= from a supervised helper process, so the pool
+gen-server is never blocked.  However, stopping members count against
+=max_count= until they actually die, so a slow =stop_mfa= reduces available
+capacity during teardown.
 
-The =stop_mfa= pool configuration parameter lets you override this.  It follows
-the same ={M, F, A}= convention with the ='$pooler_pid'= placeholder:
+The =stop_mfa= pool configuration parameter lets you override the default.
+It follows the same ={M, F, A}= convention with the ='$pooler_pid'= placeholder:
 
 #+BEGIN_SRC erlang
 #{name => pg_pool,
@@ -243,9 +236,28 @@ the same ={M, F, A}= convention with the ='$pooler_pid'= placeholder:
   stop_mfa => {my_conn, close, ['$pooler_pid']}}
 #+END_SRC
 
-The callback is called instead of =supervisor:terminate_child/2=.  If you want
-teardown to be fully asynchronous (fire-and-forget), make your callback send a
-message rather than blocking.
+The callback is called from the helper process instead of
+=supervisor:terminate_child/2=.  For maximum throughput under churn, prefer a
+fast or fire-and-forget teardown so that slots are freed quickly.
+
+**** Pools with slow-starting or slow-stopping workers
+
+For pools whose workers take significant time to start (e.g. opening a database
+or network connection), the recommended configuration pattern is:
+
+- Use =initialize_mfa= to perform the slow part of initialization (TCP handshake,
+  protocol negotiation, etc.) after =start_link= returns.  Each worker's
+  =start_link= completes quickly and multiple workers initialize in parallel.
+- Raise =member_start_timeout= to give workers enough time to finish.
+- Set =auto_grow_threshold= so the pool begins growing toward =max_count=
+  while free members still exist, giving slow workers time to initialize before
+  demand peaks.
+- Use =take_member/2= with a non-zero timeout so callers wait in the queue while
+  workers are starting rather than immediately receiving =error_no_members=.
+- Set =queue_max= to match the expected peak of concurrent callers.
+
+For pools with workers that are slow to stop, use =stop_mfa= with a fast
+asynchronous teardown so that the pool is not blocked while workers drain.
 
 *** Pool Configuration via =pooler:new_pool=
 You can create pools using =pooler:new_pool/1= when accepts a
@@ -280,13 +292,13 @@ Here's an example session:
 
 #+BEGIN_SRC erlang
 pooler:start().
-P = pooler:take_member(mysql),
+P = pooler:take_member(mysql, 5000),
 % use P
 pooler:return_member(mysql, P, ok).
 #+END_SRC
 
 Once started, the main interaction you will have with pooler is
-through two functions, =take_member/1= and =return_member/3= (or
+through two functions, =take_member= and =return_member/3= (or
 =return_member/2=).
 
 Call =pooler:take_member(Pool)= to obtain the pid belonging to a
@@ -298,6 +310,21 @@ member from the pool and start a new member to replace it.  If your
 process is short lived, you can omit the call to =return_member=.  In
 this case, pooler will detect the normal exit of the consumer and
 reclaim the member.
+
+=pooler:take_member/2= accepts a timeout (in milliseconds or as a
+=time_spec()= tuple).  When no member is immediately available, the
+caller is queued and waits until either a member is returned or the
+timeout expires.  Note that the timeout is /soft/: it controls how
+long the caller will wait in the queue, not the overall duration of the
+=gen_server:call= itself (which uses =infinity=).
+
+For dynamic-sized pools (=max_count > init_count=) be aware that
+=take_member/1= passes an implicit =0= timeout and therefore always
+returns =error_no_members= immediately when no member is free — even
+when the pool is actively starting new members to satisfy demand.
+=take_member/2= with a non-zero timeout queues the caller and delivers
+the next member that becomes available, including freshly started ones.
+Which variant fits best depends on your latency requirements.
 
 If you would like to obtain a member from a randomly selected pool in
 a group, call =pooler:take_group_member(Group)=. This will return a

--- a/src/pooler.erl
+++ b/src/pooler.erl
@@ -60,7 +60,7 @@
     code_change/3
 ]).
 
--vsn(2).
+-vsn(3).
 %% Bump this value and add a new clause to `code_change', if the format of `#pool{}' record changed
 
 %% ------------------------------------------------------------------
@@ -75,7 +75,6 @@
 -define(DEFAULT_AUTO_GROW_THRESHOLD, undefined).
 -define(POOLER_GROUP_TABLE, pooler_group_table).
 -define(DEFAULT_POOLER_QUEUE_MAX, 50).
--define(DEFAULT_STOP_MFA, {supervisor, terminate_child, ['$pooler_pool_name', '$pooler_pid']}).
 
 -record(pool, {
     name :: atom(),
@@ -130,6 +129,7 @@
     %% timestamp records when the start request was initiated
     %% and is used to implement start timeout.
     starting_members = [] :: [{pid(), erlang:timestamp()}],
+    stopping_count = 0 :: non_neg_integer(),
 
     %% The maximum amount of time to allow for member start.
     member_start_timeout = ?DEFAULT_MEMBER_START_TIMEOUT :: time_spec(),
@@ -142,7 +142,7 @@
 
     %% Stop callback to gracefully attempt to terminate pool members.
     %% The list of arguments must contain the fixed atom '$pooler_pid'.
-    stop_mfa = ?DEFAULT_STOP_MFA :: {atom(), atom(), [term()]},
+    stop_mfa = pooler_starter:default_stop_mfa() :: pooler_starter:stop_mfa(),
 
     %% Optional callback invoked by pooler_starter after supervisor:start_child
     %% returns but before the member is accepted into the pool. Use this to
@@ -189,7 +189,7 @@
         queue_max => non_neg_integer(),
         metrics_api => folsom | exometer,
         metrics_mod => module(),
-        stop_mfa => {module(), atom(), ['$pooler_pid' | any(), ...]},
+        stop_mfa => pooler_starter:stop_mfa(),
         initialize_mfa => {module(), atom(), ['$pooler_pid' | '$pooler_pool_name' | any(), ...]},
         auto_grow_threshold => non_neg_integer(),
         add_member_retry => non_neg_integer()
@@ -217,12 +217,13 @@
         | {queue_max, non_neg_integer()}
         | {metrics_api, folsom | exometer}
         | {metrics_mod, module()}
-        | {stop_mfa, {module(), atom(), ['$pooler_pid' | any(), ...]}}
+        | {stop_mfa, pooler_starter:stop_mfa()}
         | {initialize_mfa, undefined | {module(), atom(), ['$pooler_pid' | '$pooler_pool_name' | any(), ...]}}
         | {auto_grow_threshold, non_neg_integer()}}.
 
+-type member_status() :: free | pid() | {stopping, replace | no_replace}.
 -type free_member_info() :: {reference(), free, erlang:timestamp()}.
--type member_info() :: {reference(), free | pid(), erlang:timestamp()}.
+-type member_info() :: {reference(), member_status(), erlang:timestamp()}.
 %% See {@link pool_stats/1}
 
 -type members_map() :: #{pid() => member_info()}.
@@ -574,7 +575,7 @@ init(#{name := Name, max_count := MaxCount, init_count := InitCount, start_mfa :
         max_age = maps:get(max_age, P, ?DEFAULT_MAX_AGE),
         member_start_timeout = maps:get(member_start_timeout, P, ?DEFAULT_MEMBER_START_TIMEOUT),
         auto_grow_threshold = maps:get(auto_grow_threshold, P, ?DEFAULT_AUTO_GROW_THRESHOLD),
-        stop_mfa = maps:get(stop_mfa, P, ?DEFAULT_STOP_MFA),
+        stop_mfa = maps:get(stop_mfa, P, pooler_starter:default_stop_mfa()),
         initialize_mfa = maps:get(initialize_mfa, P, undefined),
         metrics_mod = maps:get(metrics_mod, P, pooler_no_metrics),
         metrics_api = maps:get(metrics_api, P, folsom),
@@ -646,8 +647,21 @@ handle_info({requestor_timeout, From}, Pool = #pool{queued_requestors = Requesto
 handle_info({'DOWN', MRef, process, Pid, Reason}, State) ->
     State1 =
         case maps:get(Pid, State#pool.all_members, undefined) of
-            {_PoolName, _ConsumerPid, _Time} ->
-                do_return_member(Pid, fail, State);
+            {MRef, {stopping, Flag}, _Time} ->
+                %% Expected death: member was being stopped asynchronously.
+                Pool1 = State#pool{
+                    all_members = maps:remove(Pid, State#pool.all_members),
+                    stopping_count = State#pool.stopping_count - 1
+                },
+                send_metric(Pool1, stopping_count, Pool1#pool.stopping_count, histogram),
+                case Flag of
+                    replace -> add_members_async(1, Pool1);
+                    no_replace -> Pool1
+                end;
+            {MRef, _Status, _Time} ->
+                %% Unexpected death while free or in_use. Process is already
+                %% dead — clean up directly without the async stop path.
+                handle_unexpected_member_down(Pid, State);
             undefined ->
                 case maps:get(Pid, State#pool.consumer_to_pid, undefined) of
                     {MRef, Pids} ->
@@ -676,17 +690,35 @@ terminate(_Reason, _State) ->
     ok.
 
 -spec code_change(_, _, _) -> {'ok', _}.
-code_change(
-    _OldVsn,
+%% pre-v2 tuple (24 elements) → v2 shape → v3
+code_change(_OldVsn, OldState, _Extra) when tuple_size(OldState) =:= 24 ->
+    {ok, do_upgrade_to_v3(do_upgrade_pre_v2_to_v2(OldState))};
+%% v2 #pool{} tuple (26 elements) → v3
+code_change(2, OldState, _Extra) when tuple_size(OldState) =:= 26 ->
+    {ok, do_upgrade_to_v3(OldState)};
+code_change(_, State, _Extra) ->
+    {ok, State}.
+
+%% Converts the pre-v2 (pre-1.6.0) 24-element pool tuple into the
+%% 26-element v2 shape, converting dict-based maps to Erlang maps.
+do_upgrade_pre_v2_to_v2(
     {pool, Name, Group, MaxCount, InitCount, StartMFA, FreePids, InUseCount, FreeCount, AddMemberRetry, CullInterval,
         MaxAge, MemberSup, StarterSup, AllMembers, ConsumerToPid, StartingMembers, MemberStartTimeout,
-        AutoGrowThreshold, StopMFA, MetricsMod, MetricsAPI, QueuedRequestors, QueueMax},
-    _Extra
+        AutoGrowThreshold, StopMFA, MetricsMod, MetricsAPI, QueuedRequestors, QueueMax}
 ) ->
-    {ok, #pool{
-        cull_timer = undefined,
-        all_members = maps:from_list(dict:to_list(AllMembers)),
-        consumer_to_pid = maps:from_list(dict:to_list(ConsumerToPid)),
+    {pool, Name, Group, MaxCount, InitCount, StartMFA, FreePids, InUseCount, FreeCount, AddMemberRetry, CullInterval,
+        MaxAge, undefined, MemberSup, StarterSup, maps:from_list(dict:to_list(AllMembers)),
+        maps:from_list(dict:to_list(ConsumerToPid)), StartingMembers, MemberStartTimeout, AutoGrowThreshold, StopMFA,
+        undefined, MetricsMod, MetricsAPI, QueuedRequestors, QueueMax}.
+
+%% Converts a v2 26-element pool tuple to a vsn(3) #pool{} record,
+%% adding stopping_count = 0.
+do_upgrade_to_v3(
+    {pool, Name, Group, MaxCount, InitCount, StartMFA, FreePids, InUseCount, FreeCount, AddMemberRetry, CullInterval,
+        MaxAge, CullTimer, MemberSup, StarterSup, AllMembers, ConsumerToPid, StartingMembers, MemberStartTimeout,
+        AutoGrowThreshold, StopMFA, InitializeMFA, MetricsMod, MetricsAPI, QueuedRequestors, QueueMax}
+) ->
+    #pool{
         name = Name,
         group = Group,
         max_count = MaxCount,
@@ -698,19 +730,22 @@ code_change(
         add_member_retry = AddMemberRetry,
         cull_interval = CullInterval,
         max_age = MaxAge,
+        cull_timer = CullTimer,
         member_sup = MemberSup,
         starter_sup = StarterSup,
+        all_members = AllMembers,
+        consumer_to_pid = ConsumerToPid,
         starting_members = StartingMembers,
+        stopping_count = 0,
         member_start_timeout = MemberStartTimeout,
         auto_grow_threshold = AutoGrowThreshold,
         stop_mfa = StopMFA,
+        initialize_mfa = InitializeMFA,
         metrics_mod = MetricsMod,
         metrics_api = MetricsAPI,
         queued_requestors = QueuedRequestors,
         queue_max = QueueMax
-    }};
-code_change(_, State, _Extra) ->
-    {ok, State}.
+    }.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
@@ -918,6 +953,7 @@ take_member_from_pool(
         free_pids = Free,
         in_use_count = NumInUse,
         free_count = NumFree,
+        stopping_count = StoppingCount,
         starting_members = StartingMembers,
         member_start_timeout = StartTimeout
     } = Pool,
@@ -926,7 +962,7 @@ take_member_from_pool(
     send_metric(Pool, take_rate, 1, meter),
     Pool1 = remove_stale_starting_members(Pool, StartingMembers, StartTimeout),
     NonStaleStartingMemberCount = length(Pool1#pool.starting_members),
-    NumCanAdd = Max - (NumInUse + NumFree + NonStaleStartingMemberCount),
+    NumCanAdd = Max - (NumInUse + NumFree + NonStaleStartingMemberCount + StoppingCount),
     case Free of
         [] when NumCanAdd =< 0 ->
             send_metric(Pool, error_no_members_count, {inc, 1}, counter),
@@ -1029,6 +1065,9 @@ do_return_member(
                 #{domain => [pooler]}
             ),
             Pool;
+        {_, {stopping, _}, _} ->
+            %% member is being stopped asynchronously — ignore this return
+            Pool;
         {MRef, CPid, _} ->
             #pool{
                 free_pids = Free,
@@ -1055,13 +1094,16 @@ do_return_member(
             Pool
     end;
 do_return_member(Pid, fail, #pool{all_members = AllMembers} = Pool) ->
-    % for the fail case, perhaps the member crashed and was alerady
+    % for the fail case, perhaps the member crashed and was already
     % removed, so use find instead of fetch and ignore missing.
     clean_group_table(Pid, Pool),
     case maps:get(Pid, AllMembers, undefined) of
+        {_MRef, {stopping, _}, _} ->
+            %% already being stopped asynchronously — ignore
+            Pool;
         {_MRef, _, _} ->
-            Pool1 = remove_pid(Pid, Pool),
-            add_members_async(1, Pool1);
+            %% replacement is triggered when the member's DOWN arrives
+            remove_pid(Pid, Pool, replace);
         undefined ->
             Pool
     end.
@@ -1097,13 +1139,43 @@ cpmap_remove(Pid, CPid, CPMap) ->
             CPMap
     end.
 
-% @doc Remove and kill a pool member.
+% @doc Handle a member process that died unexpectedly (not via async stop).
 %
-% Handles in-use and free members.  Logs an error if the pid is not
-% tracked in state.all_members.
+% The process is already dead so we clean up pool state directly and
+% start a replacement, bypassing the async stop machinery.
+handle_unexpected_member_down(Pid, Pool) ->
+    clean_group_table(Pid, Pool),
+    AllMembers = Pool#pool.all_members,
+    case maps:get(Pid, AllMembers, undefined) of
+        {_, free, _} ->
+            Pool1 = Pool#pool{
+                free_pids = lists:delete(Pid, Pool#pool.free_pids),
+                free_count = Pool#pool.free_count - 1,
+                all_members = maps:remove(Pid, AllMembers)
+            },
+            send_metric(Pool1, killed_free_count, {inc, 1}, counter),
+            add_members_async(1, Pool1);
+        {_, CPid, _} ->
+            Pool1 = Pool#pool{
+                in_use_count = Pool#pool.in_use_count - 1,
+                all_members = maps:remove(Pid, AllMembers),
+                consumer_to_pid = cpmap_remove(Pid, CPid, Pool#pool.consumer_to_pid)
+            },
+            send_metric(Pool1, killed_in_use_count, {inc, 1}, counter),
+            add_members_async(1, Pool1);
+        undefined ->
+            Pool
+    end.
+
+% @doc Initiate async removal of a pool member.
 %
--spec remove_pid(pid(), #pool{}) -> #pool{}.
-remove_pid(Pid, Pool) ->
+% Tags the member as stopping (keeping it in all_members so it counts
+% against max_count), spawns a supervised stopper, and returns
+% immediately.  The pool learns the member has actually died via its
+% monitor DOWN message.
+%
+-spec remove_pid(pid(), #pool{}, replace | no_replace) -> #pool{}.
+remove_pid(Pid, Pool, Flag) ->
     #pool{
         name = PoolName,
         all_members = AllMembers,
@@ -1111,26 +1183,28 @@ remove_pid(Pid, Pool) ->
         stop_mfa = StopMFA
     } = Pool,
     case maps:get(Pid, AllMembers, undefined) of
-        {MRef, free, _Time} ->
-            % remove an unused member
-            erlang:demonitor(MRef, [flush]),
-            FreePids = lists:delete(Pid, Pool#pool.free_pids),
-            NumFree = Pool#pool.free_count - 1,
-            Pool1 = Pool#pool{free_pids = FreePids, free_count = NumFree},
-            terminate_pid(PoolName, Pid, StopMFA),
+        {MRef, free, Time} ->
+            Pool1 = Pool#pool{
+                free_pids = lists:delete(Pid, Pool#pool.free_pids),
+                free_count = Pool#pool.free_count - 1,
+                stopping_count = Pool#pool.stopping_count + 1,
+                all_members = AllMembers#{Pid => {MRef, {stopping, Flag}, Time}}
+            },
+            pooler_starter_sup:new_stopper(pooler_starter:stop_spec(PoolName, Pid, StopMFA)),
             send_metric(Pool1, killed_free_count, {inc, 1}, counter),
-            Pool1#pool{all_members = maps:remove(Pid, AllMembers)};
-        {MRef, CPid, _Time} ->
-            %% remove a member being consumed. No notice is sent to
-            %% the consumer.
-            erlang:demonitor(MRef, [flush]),
-            Pool1 = Pool#pool{in_use_count = Pool#pool.in_use_count - 1},
-            terminate_pid(PoolName, Pid, StopMFA),
+            send_metric(Pool1, stopping_count, Pool1#pool.stopping_count, histogram),
+            Pool1;
+        {MRef, CPid, Time} ->
+            Pool1 = Pool#pool{
+                in_use_count = Pool#pool.in_use_count - 1,
+                stopping_count = Pool#pool.stopping_count + 1,
+                all_members = AllMembers#{Pid => {MRef, {stopping, Flag}, Time}},
+                consumer_to_pid = cpmap_remove(Pid, CPid, CPMap)
+            },
+            pooler_starter_sup:new_stopper(pooler_starter:stop_spec(PoolName, Pid, StopMFA)),
             send_metric(Pool1, killed_in_use_count, {inc, 1}, counter),
-            Pool1#pool{
-                consumer_to_pid = cpmap_remove(Pid, CPid, CPMap),
-                all_members = maps:remove(Pid, AllMembers)
-            };
+            send_metric(Pool1, stopping_count, Pool1#pool.stopping_count, histogram),
+            Pool1;
         undefined ->
             ?LOG_ERROR(
                 #{
@@ -1207,7 +1281,7 @@ cull_members_from_pool(
                     expired_free_members(MemberInfo, os:timestamp(), MaxAge),
                 CullList = lists:sublist(ExpiredMembers, MaxCull),
                 lists:foldl(
-                    fun({CullMe, _}, S) -> remove_pid(CullMe, S) end,
+                    fun({CullMe, _}, S) -> remove_pid(CullMe, S, no_replace) end,
                     Pool,
                     CullList
                 );
@@ -1259,7 +1333,7 @@ calculate_reconfigure_actions(
         max_age => ?DEFAULT_MAX_AGE,
         member_start_timeout => ?DEFAULT_MEMBER_START_TIMEOUT,
         auto_grow_threshold => ?DEFAULT_AUTO_GROW_THRESHOLD,
-        stop_mfa => ?DEFAULT_STOP_MFA,
+        stop_mfa => pooler_starter:default_stop_mfa(),
         initialize_mfa => undefined,
         metrics_mod => pooler_no_metrics,
         metrics_api => folsom,
@@ -1395,7 +1469,7 @@ apply_reconfigure_action({set_parameter, {Name, Value}}, Pool) ->
 apply_reconfigure_action({start_workers, Count}, Pool) ->
     add_members_async(Count, Pool);
 apply_reconfigure_action({stop_free_workers, Count}, #pool{free_pids = Free} = Pool) ->
-    lists:foldl(fun remove_pid/2, Pool, lists:sublist(Free, Count));
+    lists:foldl(fun(P, S) -> remove_pid(P, S, no_replace) end, Pool, lists:sublist(Free, Count));
 apply_reconfigure_action({shrink_queue, Count}, #pool{queued_requestors = Q} = Pool) ->
     {ToShrink, ToKeep} = lists:split(Count, queue:to_list(Q)),
     [gen_server:reply(From, error_no_members) || {From, _TRef} <- ToShrink],
@@ -1559,22 +1633,13 @@ maybe_reply({Member, NewPool}) ->
 %% Implementation of a best-effort termination for a pool member:
 %% Terminates the pid's pool member given a MFA that gets applied. The list
 %% of arguments must contain the fixed atom ?POOLER_PID, which is replaced
-%% by the target pid. Failure to provide a valid MFA will lead to use the
-%% default callback.
--spec terminate_pid(atom(), pid(), {atom(), atom(), [term()]}) -> ok.
-terminate_pid(PoolName, Pid, {Mod, Fun, Args}) when is_list(Args) ->
-    NewArgs = pooler_starter:replace_placeholders(PoolName, Pid, Args),
-    try erlang:apply(Mod, Fun, NewArgs) of
-        _ -> ok
-    catch
-        _:_ -> terminate_pid(PoolName, Pid, ?DEFAULT_STOP_MFA)
-    end.
 
 compute_utilization(#pool{
     max_count = MaxCount,
     in_use_count = InUseCount,
     free_count = FreeCount,
     starting_members = Starting,
+    stopping_count = StoppingCount,
     queued_requestors = Queue,
     queue_max = QueueMax
 }) ->
@@ -1583,6 +1648,7 @@ compute_utilization(#pool{
         {in_use_count, InUseCount},
         {free_count, FreeCount},
         {starting_count, length(Starting)},
+        {stopping_count, StoppingCount},
         %% Note not O(n), so in pathological cases this might be expensive
         {queued_count, queue:len(Queue)},
         {queue_max, QueueMax}

--- a/src/pooler_starter.erl
+++ b/src/pooler_starter.erl
@@ -1,6 +1,6 @@
 %% @author Seth Falcon <seth@userprimary.net>
 %% @copyright 2012-2013 Seth Falcon
-%% @doc Helper gen_server to start pool members
+%% @doc Helper gen_server to manage async member lifecycle (start and stop)
 %%
 -module(pooler_starter).
 -behaviour(gen_server).
@@ -9,6 +9,7 @@
 
 -define(POOLER_POOL_NAME, '$pooler_pool_name').
 -define(POOLER_PID, '$pooler_pid').
+-define(DEFAULT_STOP_MFA, {supervisor, terminate_child, [?POOLER_POOL_NAME, ?POOLER_PID]}).
 
 %% ------------------------------------------------------------------
 %% API Function Exports
@@ -21,6 +22,8 @@
     start_member/4,
     stop_member_async/1,
     stop/1,
+    stop_spec/3,
+    default_stop_mfa/0,
     replace_placeholders/3
 ]).
 
@@ -38,19 +41,24 @@
     code_change/3
 ]).
 
--export_type([start_spec/0, start_result/0]).
+-export_type([start_spec/0, start_result/0, stop_spec/0, stop_mfa/0]).
 
 -type pool_member_sup() :: pid() | atom().
 -type parent() :: pid() | pool.
 -type initialize_mfa() :: undefined | {module(), atom(), [term()]}.
+-type stop_mfa() :: {module(), atom(), ['$pooler_pid' | '$pooler_pool_name' | term()]}.
 -type start_result() :: {StarterPid :: pid(), Result :: pid() | {error, _}}.
 -opaque start_spec() :: {pooler:pool_name(), pool_member_sup(), parent(), initialize_mfa()}.
+%% {PoolName, MemberPid, StopMFA}
+-opaque stop_spec() :: {pooler:pool_name(), pid(), stop_mfa()}.
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
--spec start_link(start_spec()) -> {ok, pid()}.
+-spec start_link(start_spec() | stop_spec()) -> {ok, pid()}.
+start_link({_, _, _} = Spec) ->
+    gen_server:start_link(?MODULE, Spec, []);
 start_link({_, _, _, _} = Spec) ->
     gen_server:start_link(?MODULE, Spec, []).
 
@@ -103,14 +111,26 @@ stop_member_async(Pid) ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 -record(starter, {
-    parent :: parent(),
+    %% start mode
+    parent :: parent() | undefined,
     pool_name :: pooler:pool_name(),
-    pool_member_sup :: pool_member_sup(),
+    pool_member_sup :: pool_member_sup() | undefined,
     initialize_mfa :: initialize_mfa(),
-    msg :: start_result() | undefined
+    msg :: start_result() | undefined,
+    %% stop mode
+    stopping_pid = undefined :: pid() | undefined,
+    stopping_mfa = undefined :: stop_mfa() | undefined
 }).
 
--spec init(start_spec()) -> {ok, #starter{}, {continue, start}}.
+-spec init(start_spec() | stop_spec()) -> {ok, #starter{}, {continue, start | stop}}.
+init({PoolName, MemberPid, StopMFA}) ->
+    {ok,
+        #starter{
+            pool_name = PoolName,
+            stopping_pid = MemberPid,
+            stopping_mfa = StopMFA
+        },
+        {continue, stop}};
 init({PoolName, PoolMemberSup, Parent, InitMFA}) ->
     {ok, #starter{pool_name = PoolName, pool_member_sup = PoolMemberSup, parent = Parent, initialize_mfa = InitMFA},
         {continue, start}}.
@@ -122,7 +142,13 @@ handle_continue(
     Msg = do_start_member(PoolSup, PoolName, InitMFA),
     % asynchronously in order to receive potential `stop*'
     accept_member_async(self()),
-    {noreply, State#starter{msg = Msg}}.
+    {noreply, State#starter{msg = Msg}};
+handle_continue(
+    stop,
+    #starter{pool_name = PoolName, stopping_pid = MemberPid, stopping_mfa = StopMFA} = State
+) ->
+    terminate_pid(PoolName, MemberPid, StopMFA),
+    {stop, normal, State}.
 
 handle_call(_Request, _From, State) ->
     {noreply, State}.
@@ -186,6 +212,23 @@ do_start_member(PoolSup, PoolName, InitMFA) ->
                 #{domain => [pooler]}
             ),
             {self(), Error}
+    end.
+
+-spec default_stop_mfa() -> stop_mfa().
+default_stop_mfa() ->
+    ?DEFAULT_STOP_MFA.
+
+-spec stop_spec(pooler:pool_name(), pid(), stop_mfa()) -> stop_spec().
+stop_spec(PoolName, MemberPid, StopMFA) ->
+    {PoolName, MemberPid, StopMFA}.
+
+-spec terminate_pid(pooler:pool_name(), pid(), stop_mfa()) -> ok.
+terminate_pid(PoolName, Pid, {Mod, Fun, Args}) when is_list(Args) ->
+    NewArgs = replace_placeholders(PoolName, Pid, Args),
+    try erlang:apply(Mod, Fun, NewArgs) of
+        _ -> ok
+    catch
+        _:_ -> terminate_pid(PoolName, Pid, ?DEFAULT_STOP_MFA)
     end.
 
 -spec replace_placeholders(pooler:pool_name(), pid(), [term()]) -> [term()].

--- a/src/pooler_starter_sup.erl
+++ b/src/pooler_starter_sup.erl
@@ -1,19 +1,24 @@
 %% @doc Simple one for one supervisor for pooler_starter.
 %%
 %% This supervisor is shared by all pools since pooler_starter is a
-%% generic helper to fasciliate async member start.
+%% generic helper to facilitate async member lifecycle (start and stop).
 -module(pooler_starter_sup).
 
 -behaviour(supervisor).
 
 -export([
     new_starter/1,
+    new_stopper/1,
     start_link/0,
     init/1
 ]).
 
 -spec new_starter(pooler_starter:start_spec()) -> {ok, pid()}.
 new_starter(Spec) ->
+    supervisor:start_child(?MODULE, [Spec]).
+
+-spec new_stopper(pooler_starter:stop_spec()) -> {ok, pid()}.
+new_stopper(Spec) ->
     supervisor:start_child(?MODULE, [Spec]).
 
 start_link() ->

--- a/test/pooled_gs.erl
+++ b/test/pooled_gs.erl
@@ -23,6 +23,7 @@
     error_on_call/1,
     do_work/2,
     stop/1,
+    stop_blocking/2,
     initialize/1,
     initialize_fail/1,
     initialize_crash/1
@@ -80,6 +81,9 @@ error_on_call(S) ->
 stop(S) ->
     gen_server:call(S, stop).
 
+stop_blocking(Coordinator, Pid) ->
+    gen_server:call(Pid, {stop_blocking, Coordinator}, infinity).
+
 initialize(Pid) ->
     pong = gen_server:call(Pid, ping),
     ok.
@@ -96,7 +100,8 @@ initialize_crash(_Pid) ->
 -record(state, {
     type = "" :: string(),
     id :: reference(),
-    ping_count = 0 :: non_neg_integer()
+    ping_count = 0 :: non_neg_integer(),
+    blocked_from = undefined :: gen_server:from() | undefined
 }).
 
 init({Type}) ->
@@ -118,6 +123,9 @@ handle_call(ping_count, _From, #state{ping_count = C} = State) ->
     {reply, C, State};
 handle_call(error_on_call, _From, _State) ->
     erlang:error({pooled_gs, requested_error});
+handle_call({stop_blocking, Coordinator}, From, State) ->
+    Coordinator ! {stopping, self()},
+    {noreply, State#state{blocked_from = From}};
 handle_call(stop, _From, State) ->
     {stop, normal, stop_ok, State};
 handle_call(_Request, _From, State) ->
@@ -128,6 +136,9 @@ handle_cast(crash, _State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+handle_info(do_stop, #state{blocked_from = From} = State) ->
+    gen_server:reply(From, ok),
+    {stop, normal, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/test/pooler_tests.erl
+++ b/test/pooler_tests.erl
@@ -1596,6 +1596,134 @@ monitor_members_trigger_culling_and_return_reason() ->
     after 250 -> timeout
     end.
 
+pooler_async_stop_test_() ->
+    %% ?FUNCTION_NAME is used as the registered coordinator name so that each
+    %% test fun can do register(?FUNCTION_NAME, self()) and receive {stopping,_}
+    %% in the correct process regardless of EUnit's process model.
+    {foreach,
+        fun() ->
+            logger:set_handler_config(default, filters, []),
+            PoolConf = #{
+                name => test_pool_1,
+                max_count => 2,
+                init_count => 2,
+                start_mfa => {pooled_gs, start_link, [{type}]},
+                stop_mfa => {pooled_gs, stop_blocking, [?FUNCTION_NAME, '$pooler_pid']}
+            },
+            application:set_env(pooler, pools, [PoolConf]),
+            ok = application:start(pooler)
+        end,
+        fun(_) ->
+            catch unregister(?FUNCTION_NAME),
+            application:stop(pooler)
+        end,
+        [
+            {"stopping_count is tracked while stops are in flight", fun() ->
+                register(?FUNCTION_NAME, self()),
+                [P1, P2] = get_n_pids(test_pool_1, 2, []),
+                pooler:return_member(test_pool_1, P1, fail),
+                pooler:return_member(test_pool_1, P2, fail),
+                %% Both members are now stopping; replacements must not start yet
+                %% because stopping_count (2) fills the capacity (max_count = 2)
+                Util = maps:from_list(pooler:pool_utilization(test_pool_1)),
+                ?assertEqual(2, maps:get(stopping_count, Util)),
+                ?assertEqual(0, maps:get(starting_count, Util)),
+                %% Release both stops by signalling the members directly
+                receive
+                    {stopping, MP1} -> MP1 ! do_stop
+                after 5000 -> error(timeout_1)
+                end,
+                receive
+                    {stopping, MP2} -> MP2 ! do_stop
+                after 5000 -> error(timeout_2)
+                end,
+                wait_for_pool_state(test_pool_1, 2000, fun(U) ->
+                    maps:get(free_count, U) =:= 2 andalso
+                        maps:get(stopping_count, U) =:= 0
+                end)
+            end},
+            {"capacity never exceeded during stop+replace cycle", fun() ->
+                register(?FUNCTION_NAME, self()),
+                MemberSup = pooler_pool_sup:build_member_sup_name(test_pool_1),
+                [P1, P2] = get_n_pids(test_pool_1, 2, []),
+                pooler:return_member(test_pool_1, P1, fail),
+                pooler:return_member(test_pool_1, P2, fail),
+                %% While stopping, active children must not exceed max_count
+                Counts = supervisor:count_children(MemberSup),
+                Active = proplists:get_value(active, Counts, 0),
+                ?assert(Active =< 2),
+                receive
+                    {stopping, MP1} -> MP1 ! do_stop
+                after 5000 -> error(timeout_1)
+                end,
+                receive
+                    {stopping, MP2} -> MP2 ! do_stop
+                after 5000 -> error(timeout_2)
+                end,
+                wait_for_pool_state(test_pool_1, 2000, fun(U) ->
+                    maps:get(stopping_count, U) =:= 0
+                end),
+                Counts2 = supervisor:count_children(MemberSup),
+                Active2 = proplists:get_value(active, Counts2, 0),
+                ?assert(Active2 =< 2)
+            end},
+            {"culling does not trigger replacement", fun() ->
+                register(?FUNCTION_NAME, self()),
+                %% init_count=0 so all free members are above init_count and eligible for culling
+                {ok, _} = pooler:new_pool(#{
+                    name => test_pool_cull,
+                    max_count => 2,
+                    init_count => 0,
+                    cull_interval => {100, ms},
+                    max_age => {0, sec},
+                    start_mfa => {pooled_gs, start_link, [{type}]},
+                    stop_mfa => {pooled_gs, stop_blocking, [?FUNCTION_NAME, '$pooler_pid']}
+                }),
+                %% Take and return 2 members so free_count=2 > init_count=0 → MaxCull=2
+                [P1, P2] = get_n_pids(test_pool_cull, 2, []),
+                pooler:return_member(test_pool_cull, P1),
+                pooler:return_member(test_pool_cull, P2),
+                timer:sleep(200),
+                receive
+                    {stopping, MP1} -> MP1 ! do_stop
+                after 5000 -> error(timeout_1)
+                end,
+                receive
+                    {stopping, MP2} -> MP2 ! do_stop
+                after 5000 -> error(timeout_2)
+                end,
+                wait_for_pool_state(test_pool_cull, 2000, fun(U) ->
+                    maps:get(stopping_count, U) =:= 0
+                end),
+                ?assertEqual(0, maps:get(free_count, maps:from_list(pooler:pool_utilization(test_pool_cull)))),
+                pooler:rm_pool(test_pool_cull)
+            end},
+            {"pool_utilization exposes stopping_count", fun() ->
+                Util = maps:from_list(pooler:pool_utilization(test_pool_1)),
+                ?assert(maps:is_key(stopping_count, Util)),
+                ?assertEqual(0, maps:get(stopping_count, Util))
+            end}
+        ]}.
+
+wait_for_pool_state(Pool, Timeout, Fun) ->
+    wait_for_pool_state(Pool, Timeout, Fun, erlang:monotonic_time(millisecond)).
+
+wait_for_pool_state(Pool, Timeout, Fun, Start) ->
+    Util = maps:from_list(pooler:pool_utilization(Pool)),
+    case Fun(Util) of
+        true ->
+            ok;
+        false ->
+            Now = erlang:monotonic_time(millisecond),
+            case Now - Start >= Timeout of
+                true ->
+                    error(timeout);
+                false ->
+                    timer:sleep(20),
+                    wait_for_pool_state(Pool, Timeout, Fun, Start)
+            end
+    end.
+
 time_as_millis_test_() ->
     Zeros = [{{0, U}, 0} || U <- [min, sec, ms, mu]],
     Ones = [

--- a/test/prop_pooler.erl
+++ b/test/prop_pooler.erl
@@ -31,8 +31,8 @@ prop_fixed_start() ->
                 max_count => Size
             },
             fun() ->
-                %% Pool is not utilized
                 pool_is_free(?FUNCTION_NAME, Size),
+                assert_worker_count_bounded(?FUNCTION_NAME, Size),
                 true
             end
         )
@@ -61,10 +61,9 @@ prop_fixed_checkout_all() ->
                         take_n(?FUNCTION_NAME, 0, Size)
                     )
                 ),
-                %% Fixed pool - can't take more members than pool size
                 ?assertEqual(error_no_members, pooler:take_member(?FUNCTION_NAME, 10)),
-                %% Pool is fully utilized
                 pool_is_utilized(?FUNCTION_NAME, self(), Size),
+                assert_worker_count_bounded(?FUNCTION_NAME, Size),
                 true
             end
         )
@@ -106,8 +105,8 @@ prop_dynamic_checkout() ->
                 ),
                 %% Pool is fully utilized now
                 ?assertEqual(error_no_members, pooler:take_member(?FUNCTION_NAME, 10)),
-                %% Dynamic pool is fully utilized up to max_count
                 pool_is_utilized(?FUNCTION_NAME, self(), MaxCount),
+                assert_worker_count_bounded(?FUNCTION_NAME, MaxCount),
                 true
             end
         )
@@ -144,6 +143,7 @@ prop_fixed_take_return() ->
                 StatsAfter = Stats(),
                 ?assertEqual(UtilizationBefore, UtilizationAfter),
                 ?assertEqual(StatsBefore, StatsAfter),
+                assert_worker_count_bounded(?FUNCTION_NAME, Size),
                 true
             end
         )
@@ -193,6 +193,7 @@ prop_fixed_take_return_broken() ->
                 ?assertEqual(StatusBefore, StatusAfter),
                 %% however, all workers are new processes, none reused
                 ?assertEqual([], ordsets:intersection(ordsets:from_list(PidsBefore), ordsets:from_list(PidsAfter))),
+                assert_worker_count_bounded(?FUNCTION_NAME, Size),
                 true
             end
         )
@@ -263,6 +264,7 @@ prop_fixed_client_died() ->
                 StatsAfter = Stats(),
                 ?assertEqual(UtilizationBefore, UtilizationAfter),
                 ?assertEqual(StatsBefore, StatsAfter),
+                assert_worker_count_bounded(?FUNCTION_NAME, Size),
                 true
             end
         )
@@ -306,9 +308,12 @@ prop_group_take_return() ->
                     ),
                     %% Now return all the workers
                     [ok = pooler:return_group_member(?FUNCTION_NAME, Pid) || Pid <- Taken],
-                    %% All pools are free
                     lists:foreach(
                         fun(Pool) -> pool_is_free(Pool, NumWorkers) end,
+                        GroupPoolPids
+                    ),
+                    lists:foreach(
+                        fun(Pool) -> assert_worker_count_bounded(Pool, NumWorkers) end,
                         GroupPoolPids
                     ),
                     true
@@ -412,6 +417,20 @@ pool_is_free(Pool, NumWorkers) ->
         )
     ),
     true.
+
+assert_worker_count_bounded(PoolNameOrPid, MaxCount) ->
+    PoolName =
+        case is_atom(PoolNameOrPid) of
+            true ->
+                PoolNameOrPid;
+            false ->
+                {registered_name, N} = erlang:process_info(PoolNameOrPid, registered_name),
+                N
+        end,
+    MemberSup = pooler_pool_sup:build_member_sup_name(PoolName),
+    Counts = supervisor:count_children(MemberSup),
+    Active = proplists:get_value(active, Counts, 0),
+    ?assert(Active =< MaxCount).
 
 pg_start() ->
     pg:start(pg).


### PR DESCRIPTION
Instead of calling `stop_mfa` directly from pool, offload it to pooler_starter asynchronously. This protects from pool lockage in scenarios when `stop_mfa` becomes slow.

Should finally fix #104 

Benchmarks (OTP 27.3, macOS)

| Benchmark | Result |
|---|---|
| `size_5_take_return_one` | +1.0% |
| `size_1000_take_return_one` | +2.2% |
| `size_1_empty_take_no_members` | +2.6% |
| `size_5_take_return_all` | +8.0% |
| `size_500_take_return_all` | -8.0% |
| `size_500_clients_50_take_return_all` | no difference |
| `size_0_max_500_take_return_all` | **+10.9%** |
| `size_0_max_500_clients_50_take_return_all` | **+9.1%** |

Steady-state take/return benchmarks (no member replacement) are within noise. The ~10% regression in the `size_0_max_500` benchmarks is real and expected: those tests cull 500 members per iteration, each now spawning a supervised stopper process (~2.4 μs overhead per stop). In production use cases where `stop_mfa` involves network I/O, the async approach yields far larger benefits than this overhead.